### PR TITLE
feat: redesign marketing and watch-night experience

### DIFF
--- a/frontend/app/(dashboard)/dashboard/page.tsx
+++ b/frontend/app/(dashboard)/dashboard/page.tsx
@@ -1,0 +1,113 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+
+const highlights = [
+  { label: "Upcoming watch nights", value: "3", description: "Brunch classics, esports finals, and midnight premiere" },
+  { label: "Guests RSVP’d", value: "482", description: "Across six time zones" },
+  { label: "Automation cues", value: "28", description: "Ready to trigger this week" },
+]
+
+const timeline = [
+  {
+    time: "08:30",
+    title: "Brunch classics",
+    description: "Daybreak ambience, latte chat, co-host Amy",
+  },
+  {
+    time: "19:00",
+    title: "Esports finals",
+    description: "Neon pulse, hype panel, reaction burst at finale",
+  },
+  {
+    time: "23:45",
+    title: "Midnight premiere",
+    description: "Indigo glow, director Q&A, encore lounge",
+  },
+]
+
+export default function DashboardPage() {
+  return (
+    <div className="space-y-10">
+      <section className="rounded-[36px] border border-white/12 bg-[rgba(16,9,46,0.75)] p-6 sm:p-10">
+        <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+          <div className="space-y-3">
+            <p className="text-xs uppercase tracking-[0.4em] text-white/60">Today&apos;s focus</p>
+            <h1 className="text-3xl font-semibold text-white sm:text-4xl">Welcome back, host</h1>
+            <p className="text-sm text-white/70">
+              Dual ambience automation is standing by. Review your scheduled watch nights and confirm the cues you want to spotlight.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-4 text-sm text-white/70">
+            <div className="rounded-3xl border border-white/12 bg-white/5 px-4 py-3 text-center">
+              <p className="text-xs uppercase tracking-[0.4em] text-white/60">Ambience</p>
+              <p className="mt-2 text-base font-semibold text-white">Auto cycle</p>
+            </div>
+            <div className="rounded-3xl border border-white/12 bg-white/5 px-4 py-3 text-center">
+              <p className="text-xs uppercase tracking-[0.4em] text-white/60">Sync drift</p>
+              <p className="mt-2 text-base font-semibold text-white">±18 ms</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-3">
+        {highlights.map((item) => (
+          <Card key={item.label} className="border-white/12 bg-[rgba(15,9,44,0.75)]">
+            <CardHeader>
+              <p className="text-xs uppercase tracking-[0.35em] text-white/60">{item.label}</p>
+              <CardTitle className="text-3xl text-white">{item.value}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <CardDescription className="text-sm text-white/70">{item.description}</CardDescription>
+            </CardContent>
+          </Card>
+        ))}
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-[1.4fr,1fr]">
+        <Card className="border-white/12 bg-[rgba(18,10,52,0.78)]">
+          <CardHeader>
+            <CardTitle className="text-2xl text-white">Today&apos;s timeline</CardTitle>
+            <CardDescription className="text-sm text-white/70">
+              All scheduled watch nights with ambience presets and spotlight notes.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {timeline.map((event) => (
+              <div key={event.time} className="flex items-start gap-4 rounded-3xl border border-white/12 bg-white/5 p-4">
+                <div className="rounded-2xl border border-white/15 bg-white/10 px-3 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-white/70">
+                  {event.time}
+                </div>
+                <div className="space-y-1 text-sm text-white/80">
+                  <p className="text-base font-semibold text-white">{event.title}</p>
+                  <p>{event.description}</p>
+                </div>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+        <Card className="border-white/12 bg-[rgba(15,9,44,0.75)]">
+          <CardHeader>
+            <CardTitle className="text-2xl text-white">Crew notes</CardTitle>
+            <CardDescription className="text-sm text-white/70">
+              Shared reminders before you go live.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm text-white/75">
+            <div className="rounded-3xl border border-white/12 bg-white/5 p-4">
+              <p className="text-xs uppercase tracking-[0.35em] text-white/60">Lighting</p>
+              <p className="mt-2 text-white/80">Check bedroom lamp automation for sunrise screening.</p>
+            </div>
+            <div className="rounded-3xl border border-white/12 bg-white/5 p-4">
+              <p className="text-xs uppercase tracking-[0.35em] text-white/60">Co-hosts</p>
+              <p className="mt-2 text-white/80">Amy leads Q&A; Ravi handles spoiler-safe chat moderation.</p>
+            </div>
+            <div className="rounded-3xl border border-white/12 bg-white/5 p-4">
+              <p className="text-xs uppercase tracking-[0.35em] text-white/60">Sponsors</p>
+              <p className="mt-2 text-white/80">Upload new bumper loop before midnight premiere.</p>
+            </div>
+          </CardContent>
+        </Card>
+      </section>
+    </div>
+  )
+}

--- a/frontend/app/(dashboard)/layout.tsx
+++ b/frontend/app/(dashboard)/layout.tsx
@@ -1,0 +1,10 @@
+import type { ReactNode } from "react"
+import { DashboardLayout } from "@/components/dashboard/dashboard-layout"
+
+type LayoutProps = {
+  children: ReactNode
+}
+
+export default function DashboardRouteGroupLayout({ children }: LayoutProps) {
+  return <DashboardLayout>{children}</DashboardLayout>
+}

--- a/frontend/app/(dashboard)/library/page.tsx
+++ b/frontend/app/(dashboard)/library/page.tsx
@@ -1,0 +1,55 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+
+const media = [
+  {
+    title: "Festival premiere: Aurora Skies",
+    type: "Feature film",
+    duration: "122 min",
+    ambience: "Sunset gold",
+  },
+  {
+    title: "Esports finals: Rift Legends",
+    type: "Live event",
+    duration: "2h 30m",
+    ambience: "Neon pulse",
+  },
+  {
+    title: "Indie shorts: Midnight Stories",
+    type: "Anthology",
+    duration: "68 min",
+    ambience: "Indigo hush",
+  },
+]
+
+export default function LibraryPage() {
+  return (
+    <div className="space-y-10">
+      <section className="rounded-[36px] border border-white/12 bg-[rgba(16,9,46,0.75)] p-6 sm:p-10">
+        <div className="space-y-3">
+          <p className="text-xs uppercase tracking-[0.4em] text-white/60">Library</p>
+          <h1 className="text-3xl font-semibold text-white sm:text-4xl">Curate your watch night catalogue</h1>
+          <p className="text-sm text-white/70">
+            Upload media, assign ambience presets, and save timelines so every repeat screening launches instantly.
+          </p>
+        </div>
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-3">
+        {media.map((item) => (
+          <Card key={item.title} className="border-white/12 bg-[rgba(15,9,44,0.75)]">
+            <CardHeader>
+              <CardTitle className="text-lg text-white">{item.title}</CardTitle>
+              <p className="text-xs uppercase tracking-[0.35em] text-white/60">{item.type}</p>
+            </CardHeader>
+            <CardContent className="space-y-2 text-sm text-white/80">
+              <CardDescription className="text-sm text-white/70">Duration: {item.duration}</CardDescription>
+              <div className="rounded-3xl border border-white/12 bg-white/5 px-3 py-1 text-xs uppercase tracking-[0.35em] text-white/60">
+                Ambience: {item.ambience}
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </section>
+    </div>
+  )
+}

--- a/frontend/app/(dashboard)/rooms/page.tsx
+++ b/frontend/app/(dashboard)/rooms/page.tsx
@@ -1,0 +1,55 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+
+const rooms = [
+  {
+    name: "Sunrise salon",
+    theme: "Daybreak",
+    status: "Live in 2h",
+    details: "Playlist: brunch classics · 46 RSVPs",
+  },
+  {
+    name: "Esports arena",
+    theme: "Neon pulse",
+    status: "Live now",
+    details: "Playlist: championship finals · 220 live viewers",
+  },
+  {
+    name: "Midnight cinema",
+    theme: "Indigo hush",
+    status: "Live in 6h",
+    details: "Playlist: director premiere · 216 RSVPs",
+  },
+]
+
+export default function RoomsPage() {
+  return (
+    <div className="space-y-10">
+      <section className="rounded-[36px] border border-white/12 bg-[rgba(16,9,46,0.75)] p-6 sm:p-10">
+        <div className="space-y-3">
+          <p className="text-xs uppercase tracking-[0.4em] text-white/60">Rooms</p>
+          <h1 className="text-3xl font-semibold text-white sm:text-4xl">Manage your watch lounges</h1>
+          <p className="text-sm text-white/70">
+            Preview ambience, adjust automation cues, and confirm who&apos;s on the co-host roster before doors open.
+          </p>
+        </div>
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-3">
+        {rooms.map((room) => (
+          <Card key={room.name} className="border-white/12 bg-[rgba(15,9,44,0.75)]">
+            <CardHeader>
+              <CardTitle className="text-xl text-white">{room.name}</CardTitle>
+              <p className="text-xs uppercase tracking-[0.35em] text-white/60">{room.theme}</p>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm text-white/75">
+              <CardDescription className="text-sm text-white/70">{room.details}</CardDescription>
+              <div className="inline-flex items-center gap-2 rounded-full border border-white/12 bg-white/5 px-3 py-1 text-xs uppercase tracking-[0.35em] text-white/60">
+                {room.status}
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </section>
+    </div>
+  )
+}

--- a/frontend/app/(dashboard)/settings/page.tsx
+++ b/frontend/app/(dashboard)/settings/page.tsx
@@ -1,0 +1,70 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+
+const preferences = [
+  {
+    title: "Ambience defaults",
+    description: "Start new rooms with daybreak ambience and auto-cycle to midnight during finale.",
+  },
+  {
+    title: "Crew permissions",
+    description: "Allow co-hosts to trigger reaction bursts and polls while keeping playback controls locked to hosts.",
+  },
+  {
+    title: "Notifications",
+    description: "Send guests SMS reminders 15 minutes before the room opens and highlight ambience theme in the message.",
+  },
+]
+
+export default function SettingsPage() {
+  return (
+    <div className="space-y-10">
+      <section className="rounded-[36px] border border-white/12 bg-[rgba(16,9,46,0.75)] p-6 sm:p-10">
+        <div className="space-y-3">
+          <p className="text-xs uppercase tracking-[0.4em] text-white/60">Settings</p>
+          <h1 className="text-3xl font-semibold text-white sm:text-4xl">Fine-tune your host preferences</h1>
+          <p className="text-sm text-white/70">
+            Customize ambience defaults, crew permissions, and communication so every watch night stays on brand.
+          </p>
+        </div>
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-3">
+        {preferences.map((preference) => (
+          <Card key={preference.title} className="border-white/12 bg-[rgba(15,9,44,0.75)]">
+            <CardHeader>
+              <CardTitle className="text-lg text-white">{preference.title}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <CardDescription className="text-sm text-white/70">{preference.description}</CardDescription>
+            </CardContent>
+          </Card>
+        ))}
+      </section>
+
+      <section className="rounded-[36px] border border-white/12 bg-[rgba(15,9,44,0.75)] p-6 sm:p-10">
+        <Card className="border-white/12 bg-[rgba(18,10,52,0.8)]">
+          <CardHeader>
+            <CardTitle className="text-2xl text-white">Integrations</CardTitle>
+            <CardDescription className="text-sm text-white/70">
+              Connect automation tools and streaming sources.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm text-white/75">
+            <div className="rounded-3xl border border-white/12 bg-white/5 p-4">
+              <p className="text-xs uppercase tracking-[0.35em] text-white/60">Lighting</p>
+              <p className="mt-2 text-white/80">Philips Hue · LIFX</p>
+            </div>
+            <div className="rounded-3xl border border-white/12 bg-white/5 p-4">
+              <p className="text-xs uppercase tracking-[0.35em] text-white/60">Streaming</p>
+              <p className="mt-2 text-white/80">YouTube Live · Vimeo · RTMP</p>
+            </div>
+            <div className="rounded-3xl border border-white/12 bg-white/5 p-4">
+              <p className="text-xs uppercase tracking-[0.35em] text-white/60">Community</p>
+              <p className="mt-2 text-white/80">Discord · Slack · Custom webhooks</p>
+            </div>
+          </CardContent>
+        </Card>
+      </section>
+    </div>
+  )
+}

--- a/frontend/app/(public)/about/page.tsx
+++ b/frontend/app/(public)/about/page.tsx
@@ -1,0 +1,135 @@
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+
+const timeline = [
+  {
+    year: "2020",
+    title: "Weekend experiments",
+    description:
+      "WatchParty started as a living room hack to sync film club meetups. Our first prototype dimmed Hue lights across four apartments and aligned captions perfectly.",
+  },
+  {
+    year: "2021",
+    title: "Festival debut",
+    description:
+      "Independent directors streamed premieres across time zones. The dual ambience engine was born so Q&As at sunrise flowed into neon midnight encores.",
+  },
+  {
+    year: "2023",
+    title: "Creator collectives",
+    description:
+      "Esports crews, classrooms, and fandom communities replaced screen shares with cinematic lobbies, spoiler-safe chat, and automated rituals.",
+  },
+]
+
+export default function AboutPage() {
+  return (
+    <div className="space-y-16">
+      <section className="relative overflow-hidden rounded-[48px] border border-white/12 bg-[rgba(12,7,34,0.78)] px-8 py-16 shadow-[0_55px_150px_rgba(5,3,24,0.6)] sm:px-12 lg:px-20">
+        <div className="absolute inset-0 opacity-80">
+          <div className="absolute inset-0 bg-[conic-gradient(from_120deg_at_60%_25%,rgba(255,255,255,0.18),rgba(255,214,170,0.32),rgba(58,34,108,0.45),rgba(255,255,255,0.12))]" />
+          <div className="grid-overlay" />
+        </div>
+        <div className="relative space-y-6">
+          <span className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/10 px-4 py-1 text-[11px] uppercase tracking-[0.45em] text-white/65">
+            About WatchParty
+          </span>
+          <h1 className="text-4xl font-semibold tracking-tight text-white sm:text-5xl">
+            We build a cinematic operating system for crews who host from dawn through midnight
+          </h1>
+          <p className="max-w-3xl text-lg text-white/75">
+            WatchParty pairs daylight-ready whites with twilight oklch(42% .18 15) tones. Automations handle ambience, sync, and collaboration so hosts can focus on storytelling.
+          </p>
+          <div className="flex flex-wrap gap-4">
+            <Button size="lg" asChild>
+              <Link href="/pricing">Explore plans</Link>
+            </Button>
+            <Button variant="secondary" size="lg" asChild>
+              <Link href="/guides/watch-night">Read the watch night guide</Link>
+            </Button>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-8 lg:grid-cols-[1.1fr,1fr]">
+        <Card className="border-white/12 bg-[rgba(14,8,40,0.78)]">
+          <CardHeader>
+            <CardTitle className="text-2xl">Day-to-night design principles</CardTitle>
+            <CardDescription className="text-base text-white/75">
+              Our product philosophy blends physical theatre cues with collaborative tooling. Every module respects the film while guiding conversation.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="rounded-3xl border border-white/15 bg-white/5 p-5 text-sm text-white/80">
+                <p className="text-sm font-semibold text-white">Ambience without distraction</p>
+                <p className="mt-2 text-white/70">
+                  Lighting, overlays, and sound cues complement the narrative—they never cover subtitles or the primary frame.
+                </p>
+              </div>
+              <div className="rounded-3xl border border-white/15 bg-white/5 p-5 text-sm text-white/80">
+                <p className="text-sm font-semibold text-white">Hosts stay in flow</p>
+                <p className="mt-2 text-white/70">
+                  Schedules, automation, and co-host permissions keep teams confident even when audiences scale into the thousands.
+                </p>
+              </div>
+            </div>
+            <div className="rounded-3xl border border-white/15 bg-white/5 p-6 text-sm text-white/80">
+              <p className="text-sm font-semibold text-white">Community-first rituals</p>
+              <p className="mt-2 text-white/70">
+                Pre-show lobbies, spoiler-safe threads, and reaction prompts transform remote screens into shared memories.
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+        <Card className="border-white/12 bg-[rgba(12,7,34,0.82)]">
+          <CardHeader>
+            <CardTitle className="text-2xl">Core stats</CardTitle>
+            <CardDescription className="text-base text-white/75">
+              A quick snapshot of the rooms, events, and guests who rely on WatchParty each month.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-5 text-white/80">
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="rounded-2xl border border-white/12 bg-white/5 p-4">
+                <p className="text-xs uppercase tracking-[0.35em] text-white/60">Watch nights hosted</p>
+                <p className="mt-2 text-3xl font-semibold text-white">18,400+</p>
+              </div>
+              <div className="rounded-2xl border border-white/12 bg-white/5 p-4">
+                <p className="text-xs uppercase tracking-[0.35em] text-white/60">Average guest rating</p>
+                <p className="mt-2 text-3xl font-semibold text-white">4.9 / 5</p>
+              </div>
+            </div>
+            <div className="rounded-2xl border border-white/12 bg-white/5 p-4">
+              <p className="text-xs uppercase tracking-[0.35em] text-white/60">Countries represented</p>
+              <p className="mt-2 text-3xl font-semibold text-white">62</p>
+            </div>
+            <p className="text-sm text-white/70">
+              These numbers grow as hosts bring new rituals to life—our roadmap stays focused on keeping those moments cinematic.
+            </p>
+          </CardContent>
+        </Card>
+      </section>
+
+      <section className="relative overflow-hidden rounded-[40px] border border-white/12 bg-[rgba(10,6,30,0.82)] p-8 sm:p-12">
+        <div className="absolute inset-0 opacity-70">
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.18),transparent_70%)]" />
+          <div className="grid-overlay" />
+        </div>
+        <div className="relative space-y-8">
+          <h2 className="text-2xl font-semibold text-white sm:text-3xl">Timeline</h2>
+          <div className="grid gap-6 sm:grid-cols-3">
+            {timeline.map((item) => (
+              <div key={item.year} className="space-y-3 rounded-3xl border border-white/12 bg-white/5 p-5 text-sm text-white/80">
+                <p className="text-xs uppercase tracking-[0.4em] text-white/60">{item.year}</p>
+                <p className="text-base font-semibold text-white">{item.title}</p>
+                <p className="text-white/70">{item.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/frontend/app/(public)/guides/watch-night/page.tsx
+++ b/frontend/app/(public)/guides/watch-night/page.tsx
@@ -1,0 +1,104 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+
+const steps = [
+  {
+    title: "Set the tone",
+    description:
+      "Choose a dual ambience preset and add timed cues for opening credits, intermission, and finale. Drop your soundtrack into the lobby playlist.",
+  },
+  {
+    title: "Invite the crew",
+    description:
+      "Send personalized invites that include time-zone friendly start times and the ambience preset guests will join with.",
+  },
+  {
+    title: "Stage your segments",
+    description:
+      "Stack polls, reaction prompts, and co-host spotlights on the timeline so you can stay focused on guiding discussion.",
+  },
+  {
+    title: "Go live",
+    description:
+      "WatchParty keeps playback in sync within ±18 ms while the ambience engine adapts lighting for every guest simultaneously.",
+  },
+]
+
+const tips = [
+  {
+    heading: "Dawn warm-up",
+    body: "Host a pre-show stretch or coffee chat while the room slowly brightens to daybreak hues.",
+  },
+  {
+    heading: "Intermission ritual",
+    body: "Cue polls and highlight co-host commentary as lights rise slightly to keep conversation flowing.",
+  },
+  {
+    heading: "Midnight encore",
+    body: "Trigger neon accents during credits and fade into a spoiler-safe chat lounge for post-show debates.",
+  },
+]
+
+export default function WatchNightGuidePage() {
+  return (
+    <div className="space-y-16">
+      <section className="relative overflow-hidden rounded-[48px] border border-white/12 bg-[rgba(10,6,30,0.82)] px-8 py-16 shadow-[0_60px_150px_rgba(5,3,26,0.6)] sm:px-12 lg:px-20">
+        <div className="absolute inset-0 opacity-80">
+          <div className="absolute inset-0 bg-[conic-gradient(from_140deg_at_65%_25%,rgba(255,255,255,0.18),rgba(255,214,170,0.32),rgba(58,34,108,0.45),rgba(255,255,255,0.12))]" />
+          <div className="grid-overlay" />
+        </div>
+        <div className="relative space-y-6">
+          <div className="flex flex-wrap items-center gap-3">
+            <span className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/10 px-4 py-1 text-[11px] uppercase tracking-[0.45em] text-white/65">
+              Host guide
+            </span>
+            <span className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/5 px-4 py-1 text-[11px] uppercase tracking-[0.45em] text-white/60">
+              Sunrise ↔ Midnight
+            </span>
+          </div>
+          <h1 className="text-4xl font-semibold tracking-tight text-white sm:text-5xl">
+            Craft a watch night ritual that glows from sunrise lobby to midnight encore
+          </h1>
+          <p className="max-w-3xl text-lg text-white/75">
+            Follow these steps to turn remote screenings into cinematic events. The ambience engine and stage manager keep the room aligned while you lead the conversation.
+          </p>
+        </div>
+      </section>
+
+      <section className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+        {steps.map((step, index) => (
+          <Card key={step.title} className="border-white/12 bg-[rgba(16,9,46,0.72)]">
+            <CardHeader>
+              <CardTitle className="text-xs uppercase tracking-[0.4em] text-white/60">Step {index + 1}</CardTitle>
+              <p className="text-lg font-semibold text-white">{step.title}</p>
+            </CardHeader>
+            <CardContent>
+              <CardDescription className="text-sm text-white/70">{step.description}</CardDescription>
+            </CardContent>
+          </Card>
+        ))}
+      </section>
+
+      <section className="rounded-[38px] border border-white/12 bg-[rgba(15,9,44,0.75)] p-8 sm:p-12">
+        <h2 className="text-2xl font-semibold text-white sm:text-3xl">Signature rituals</h2>
+        <div className="mt-8 grid gap-6 sm:grid-cols-3">
+          {tips.map((tip) => (
+            <div key={tip.heading} className="space-y-3 rounded-3xl border border-white/12 bg-white/5 p-5 text-sm text-white/80">
+              <p className="text-xs uppercase tracking-[0.4em] text-white/60">{tip.heading}</p>
+              <p className="text-white/70">{tip.body}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="rounded-[38px] border border-white/12 bg-[rgba(15,9,44,0.75)] p-8 sm:p-12">
+        <h2 className="text-2xl font-semibold text-white sm:text-3xl">Checklist</h2>
+        <ul className="mt-6 space-y-3 text-sm text-white/80">
+          <li>• Preview your ambience cues in the stage manager timeline.</li>
+          <li>• Assign a co-host to manage chat reactions and polls.</li>
+          <li>• Upload custom overlays or sponsor loops if you&apos;re running a premiere.</li>
+          <li>• Schedule encore slots so guests can linger in a spoiler-safe lounge.</li>
+        </ul>
+      </section>
+    </div>
+  )
+}

--- a/frontend/app/(public)/pricing/page.tsx
+++ b/frontend/app/(public)/pricing/page.tsx
@@ -1,0 +1,140 @@
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
+
+const plans = [
+  {
+    name: "Matinee",
+    price: "Free",
+    description: "For casual crews hosting up to 15 guests with day or night ambience presets.",
+    perks: [
+      "15 concurrent guests",
+      "Daybreak & midnight ambience presets",
+      "Shared watchlist and chat overlay",
+      "Two automation cues per event",
+    ],
+    cta: "Start for free",
+    href: "/dashboard",
+  },
+  {
+    name: "Premiere",
+    price: "$39 / month",
+    description: "For clubs and classrooms that need scripted rituals and co-host collaboration.",
+    perks: [
+      "250 concurrent guests",
+      "Unlimited ambience presets and transitions",
+      "Stage manager with timeline automation",
+      "Co-host roles, polls, and reaction bursts",
+    ],
+    cta: "Upgrade to Premiere",
+    href: "/dashboard",
+    featured: true,
+  },
+  {
+    name: "Marathon",
+    price: "Talk to us",
+    description: "For festivals and creator collectives delivering global premieres and marathons.",
+    perks: [
+      "10k+ concurrent guests",
+      "Dedicated success engineer",
+      "Custom ambience palettes and sponsor loops",
+      "Advanced analytics & CRM integrations",
+    ],
+    cta: "Book a call",
+    href: "mailto:hello@watchparty.tv",
+  },
+]
+
+export default function PricingPage() {
+  return (
+    <div className="space-y-16">
+      <section className="relative overflow-hidden rounded-[48px] border border-white/12 bg-[rgba(10,6,30,0.82)] px-8 py-16 shadow-[0_60px_150px_rgba(5,3,26,0.6)] sm:px-12 lg:px-20">
+        <div className="absolute inset-0 opacity-80">
+          <div className="absolute inset-0 bg-[conic-gradient(from_120deg_at_65%_25%,rgba(255,255,255,0.18),rgba(255,214,170,0.32),rgba(58,34,108,0.45),rgba(255,255,255,0.12))]" />
+          <div className="grid-overlay" />
+        </div>
+        <div className="relative space-y-6">
+          <div className="flex flex-wrap items-center gap-3">
+            <span className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/10 px-4 py-1 text-[11px] uppercase tracking-[0.45em] text-white/65">
+              Pricing
+            </span>
+            <span className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/5 px-4 py-1 text-[11px] uppercase tracking-[0.45em] text-white/60">
+              Sunrise ↔ Midnight
+            </span>
+          </div>
+          <h1 className="text-4xl font-semibold tracking-tight text-white sm:text-5xl">
+            Plans that scale from intimate matinees to global midnight premieres
+          </h1>
+          <p className="max-w-3xl text-lg text-white/75">
+            Every tier includes precision sync, dual ambience presets, and spoiler-safe chat. Upgrade when you want automated rituals, co-host orchestration, or dedicated support.
+          </p>
+        </div>
+      </section>
+
+      <section className="grid gap-8 lg:grid-cols-3">
+        {plans.map((plan) => (
+          <Card
+            key={plan.name}
+            className={
+              plan.featured
+                ? "border-white/18 bg-[rgba(16,9,48,0.85)] shadow-[0_48px_130px_rgba(8,4,36,0.6)]"
+                : "border-white/12 bg-[rgba(12,7,34,0.78)]"
+            }
+          >
+            <CardHeader>
+              <CardTitle className="text-2xl text-white">{plan.name}</CardTitle>
+              <p className="text-xs uppercase tracking-[0.4em] text-white/60">{plan.featured ? "Most popular" : ""}</p>
+              <p className="text-3xl font-semibold text-white">{plan.price}</p>
+              <CardDescription className="text-base text-white/75">{plan.description}</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ul className="space-y-3 text-sm text-white/80">
+                {plan.perks.map((perk) => (
+                  <li key={perk} className="flex items-start gap-2">
+                    <span className="mt-[6px] h-1.5 w-1.5 rounded-full bg-[var(--color-accent-500)]" aria-hidden />
+                    <span>{perk}</span>
+                  </li>
+                ))}
+              </ul>
+            </CardContent>
+            <CardFooter>
+              <Button variant={plan.featured ? "primary" : "secondary"} size="lg" asChild>
+                <Link href={plan.href}>{plan.cta}</Link>
+              </Button>
+            </CardFooter>
+          </Card>
+        ))}
+      </section>
+
+      <section className="rounded-[38px] border border-white/12 bg-[rgba(15,9,44,0.75)] p-8 sm:p-12">
+        <h2 className="text-2xl font-semibold text-white sm:text-3xl">Frequently asked</h2>
+        <div className="mt-8 grid gap-6 lg:grid-cols-2">
+          <div className="space-y-3 rounded-3xl border border-white/12 bg-white/5 p-5 text-white/80">
+            <p className="text-sm font-semibold text-white">Can I switch between ambience presets during an event?</p>
+            <p className="text-sm text-white/70">
+              Absolutely. All plans let you drop cues in real time. Premiere and Marathon automate the transitions based on your timeline.
+            </p>
+          </div>
+          <div className="space-y-3 rounded-3xl border border-white/12 bg-white/5 p-5 text-white/80">
+            <p className="text-sm font-semibold text-white">Do you support custom branding?</p>
+            <p className="text-sm text-white/70">
+              Premiere adds logo placement and sponsor bumpers. Marathon unlocks bespoke ambience palettes curated by our design team.
+            </p>
+          </div>
+          <div className="space-y-3 rounded-3xl border border-white/12 bg-white/5 p-5 text-white/80">
+            <p className="text-sm font-semibold text-white">What happens if the host drops?</p>
+            <p className="text-sm text-white/70">
+              Co-hosts automatically inherit controls and WatchParty keeps the stream running while the original host reconnects.
+            </p>
+          </div>
+          <div className="space-y-3 rounded-3xl border border-white/12 bg-white/5 p-5 text-white/80">
+            <p className="text-sm font-semibold text-white">Is there an education discount?</p>
+            <p className="text-sm text-white/70">
+              Yes—campus clubs and classrooms receive 25% off Premiere. Reach out at hello@watchparty.tv to apply the discount.
+            </p>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -4,16 +4,288 @@
 
 :root {
   color-scheme: dark;
+  --color-midnight-950: #050118;
+  --color-midnight-900: #0a0724;
+  --color-midnight-700: #141039;
+  --color-twilight-500: #2a1f54;
+  --color-twilight-400: #3a2b6a;
+  --color-horizon-200: #f4edff;
+  --color-horizon-150: #fdf9ff;
+  --color-sunrise-amber: rgba(255, 204, 150, 0.75);
+  --color-sunrise-rose: rgba(255, 178, 178, 0.75);
+  --color-accent-600: color-mix(in oklab, oklch(42% .18 15) 110%, black 12%);
+  --color-accent-500: oklch(42% .18 15);
+  --color-accent-400: color-mix(in oklab, oklch(42% .18 15) 65%, white 35%);
+  --color-text-primary: #f9f8ff;
+  --color-text-muted: rgba(241, 238, 255, 0.72);
+  --color-text-soft: rgba(241, 238, 255, 0.55);
+  --shadow-ambient: 0 60px 160px rgba(7, 5, 28, 0.65);
+  --shadow-elevated: 0 34px 120px rgba(9, 6, 36, 0.6);
+  font-feature-settings: "ss01", "cv05";
 }
 
 body {
-  @apply bg-zinc-950 text-zinc-50 antialiased;
+  position: relative;
+  min-height: 100vh;
+  background: radial-gradient(circle at 20% -10%, rgba(255, 255, 255, 0.2), transparent 55%),
+    radial-gradient(circle at 80% -5%, rgba(255, 214, 170, 0.28), transparent 60%),
+    linear-gradient(180deg, rgba(248, 245, 255, 0.07) 0%, rgba(22, 15, 54, 0.72) 45%, rgba(5, 2, 18, 0.95) 100%);
+  color: var(--color-text-primary);
+  overflow-x: hidden;
+  @apply antialiased;
+}
+
+::selection {
+  background-color: color-mix(in oklab, var(--color-accent-400) 40%, transparent);
+  color: #1c0f33;
+}
+
+body::before,
+body::after {
+  position: fixed;
+  inset: 0;
+  content: "";
+  pointer-events: none;
+  z-index: -2;
+}
+
+body::before {
+  background:
+    radial-gradient(circle at 12% 10%, rgba(255, 255, 255, 0.45), transparent 55%),
+    radial-gradient(circle at 88% 14%, rgba(255, 222, 178, 0.3), transparent 55%),
+    radial-gradient(circle at 30% 80%, rgba(110, 82, 255, 0.28), transparent 60%),
+    linear-gradient(135deg, rgba(255, 255, 255, 0.06), transparent 62%);
+  filter: blur(16px);
+  mix-blend-mode: screen;
+  opacity: 0.7;
+}
+
+body::after {
+  background:
+    radial-gradient(circle at 50% 110%, rgba(30, 19, 72, 0.95), transparent 70%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.05), transparent 40%),
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180' fill='none'%3E%3Cfilter id='b' x='0' y='0' width='100%25' height='100%25'%3E%3CfeTurbulence baseFrequency='0.8' numOctaves='3' seed='7' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='180' height='180' filter='url(%23b)' opacity='0.24'/%3E%3C/svg%3E");
+  background-size: cover;
+  mix-blend-mode: screen;
+  opacity: 0.35;
+  animation: auroraDrift 18s ease-in-out infinite alternate;
 }
 
 a {
-  @apply text-white;
+  color: inherit;
+  text-decoration-color: rgba(255, 255, 255, 0.32);
+  text-underline-offset: 6px;
+  transition: color 200ms ease, text-decoration-color 200ms ease;
+}
+
+a:hover {
+  color: var(--color-horizon-150);
+  text-decoration-color: rgba(255, 255, 255, 0.6);
 }
 
 button {
-  @apply focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:ring-offset-2 focus-visible:ring-offset-black;
+  @apply focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent;
+}
+
+.card-sheen {
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.card-sheen::before {
+  position: absolute;
+  inset: -130% -40%;
+  content: "";
+  background:
+    conic-gradient(from 120deg, transparent 5%, rgba(255, 255, 255, 0.18), transparent 55%, rgba(255, 255, 255, 0.08));
+  animation: sheenSweep 9s linear infinite;
+  opacity: 0.6;
+}
+
+.card-sheen::after {
+  position: absolute;
+  inset: 0;
+  content: "";
+  border-radius: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  mix-blend-mode: screen;
+  pointer-events: none;
+}
+
+.grid-overlay {
+  position: absolute;
+  inset: 0;
+  background-image: linear-gradient(rgba(255, 255, 255, 0.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.04) 1px, transparent 1px);
+  background-size: 44px 44px;
+  mask-image: radial-gradient(circle at center, rgba(0, 0, 0, 0.85), transparent 75%);
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+.noise-overlay {
+  position: absolute;
+  inset: 0;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160' fill='none'%3E%3Cfilter id='c' x='0' y='0' width='100%25' height='100%25'%3E%3CfeTurbulence baseFrequency='0.7' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='160' height='160' filter='url(%23c)' opacity='0.3'/%3E%3C/svg%3E");
+  mix-blend-mode: soft-light;
+  opacity: 0.18;
+  pointer-events: none;
+}
+
+.loading-reel {
+  position: relative;
+  width: 6rem;
+  height: 6rem;
+  display: grid;
+  place-items: center;
+  border-radius: 9999px;
+  background:
+    conic-gradient(from 120deg, rgba(255, 255, 255, 0.75), rgba(255, 255, 255, 0) 55%, rgba(255, 214, 170, 0.65) 75%, transparent 90%),
+    radial-gradient(circle at 28% 28%, rgba(255, 255, 255, 0.35), transparent 55%),
+    radial-gradient(circle at 72% 72%, rgba(111, 82, 255, 0.25), transparent 55%),
+    linear-gradient(135deg, rgba(255, 255, 255, 0.08), rgba(13, 6, 36, 0.65));
+  box-shadow: 0 28px 70px rgba(10, 6, 40, 0.65);
+  animation: reelOrbit 4s linear infinite;
+}
+
+.loading-reel::before {
+  content: "";
+  position: absolute;
+  inset: 18%;
+  border-radius: inherit;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(255, 255, 255, 0.22),
+      rgba(255, 255, 255, 0.22) 8px,
+      rgba(255, 255, 255, 0.05) 8px,
+      rgba(255, 255, 255, 0.05) 16px
+    );
+  mask-image: radial-gradient(circle at center, black 60%, transparent 100%);
+  animation: filmPulse 2.8s ease-in-out infinite;
+  opacity: 0.9;
+}
+
+.loading-reel::after {
+  content: "";
+  position: absolute;
+  inset: 32%;
+  border-radius: inherit;
+  background:
+    radial-gradient(circle at center, rgba(255, 255, 255, 0.4), transparent 70%),
+    repeating-linear-gradient(
+      0deg,
+      transparent,
+      transparent 10px,
+      rgba(255, 255, 255, 0.25) 10px,
+      rgba(255, 255, 255, 0.25) 18px
+    );
+  opacity: 0.8;
+  animation: reelGlow 3.4s ease-in-out infinite;
+}
+
+.skeleton {
+  position: relative;
+  overflow: hidden;
+  border-radius: 9999px;
+  background:
+    linear-gradient(90deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.18), rgba(255, 255, 255, 0.06));
+  background-size: 240px 100%;
+  animation: skeletonPan 1.8s linear infinite;
+}
+
+.skeleton::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(255, 255, 255, 0.12) 0,
+      rgba(255, 255, 255, 0.12) 12px,
+      rgba(255, 255, 255, 0.02) 12px,
+      rgba(255, 255, 255, 0.02) 20px
+    );
+  opacity: 0.4;
+  mix-blend-mode: screen;
+}
+
+.skeleton::after {
+  content: "";
+  position: absolute;
+  inset: 6% 0;
+  background:
+    repeating-linear-gradient(
+      0deg,
+      transparent,
+      transparent 12px,
+      rgba(255, 255, 255, 0.15) 12px,
+      rgba(255, 255, 255, 0.15) 16px
+    );
+  opacity: 0.35;
+}
+
+@keyframes sheenSweep {
+  0% {
+    transform: translate3d(-35%, -35%, 0) rotate(10deg);
+  }
+  50% {
+    transform: translate3d(35%, 35%, 0) rotate(10deg);
+  }
+  100% {
+    transform: translate3d(85%, 85%, 0) rotate(10deg);
+  }
+}
+
+@keyframes auroraDrift {
+  0% {
+    transform: translate3d(-2%, -2%, 0) scale(1.02);
+  }
+  50% {
+    transform: translate3d(1%, 2%, 0) scale(1.05);
+  }
+  100% {
+    transform: translate3d(2%, 4%, 0) scale(1.01);
+  }
+}
+
+@keyframes reelOrbit {
+  from {
+    transform: rotate(0deg) scale(1);
+  }
+  to {
+    transform: rotate(360deg) scale(1.03);
+  }
+}
+
+@keyframes filmPulse {
+  0%,
+  100% {
+    opacity: 0.55;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+@keyframes reelGlow {
+  0%,
+  100% {
+    opacity: 0.55;
+    transform: scale(0.94);
+  }
+  50% {
+    opacity: 0.95;
+    transform: scale(1.05);
+  }
+}
+
+@keyframes skeletonPan {
+  0% {
+    background-position: -240px 0;
+  }
+  100% {
+    background-position: 240px 0;
+  }
 }

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
     template: "%s | WatchParty",
   },
   description:
-    "Plan, host, and enjoy virtual watch parties with friends using a polished black and white cinematic interface.",
+    "Stage luminous watch parties from sunrise premieres to midnight marathons with WatchParty's day-and-night cinema toolkit.",
 }
 
 type RootLayoutProps = {
@@ -21,12 +21,23 @@ type RootLayoutProps = {
 export default function RootLayout({ children }: RootLayoutProps) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className="bg-zinc-950 text-zinc-50">
+      <body className="bg-[var(--color-midnight-950)] font-sans text-[color:var(--color-text-primary)]">
         <Providers>
-          <div className="flex min-h-screen flex-col">
+          <div className="relative flex min-h-screen flex-col overflow-hidden">
+            <div
+              aria-hidden
+              className="pointer-events-none absolute inset-0 -z-20 overflow-hidden"
+            >
+              <div className="absolute -top-32 left-1/2 h-[520px] w-[520px] -translate-x-1/2 rounded-full bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.48),transparent_65%)] opacity-60 blur-[120px]" />
+              <div className="absolute -left-56 top-16 h-[420px] w-[420px] rounded-full bg-[radial-gradient(circle_at_30%_30%,rgba(255,214,170,0.55),transparent_60%)] blur-[120px]" />
+              <div className="absolute -right-40 bottom-[-22%] h-[680px] w-[680px] rounded-full bg-[radial-gradient(circle_at_center,rgba(68,45,160,0.65),transparent_70%)] blur-[140px]" />
+              <div className="absolute inset-0 bg-[conic-gradient(from_260deg_at_20%_10%,rgba(255,255,255,0.18),rgba(20,12,52,0.35),rgba(255,255,255,0.06))] opacity-50" />
+              <div className="grid-overlay" />
+              <div className="noise-overlay" />
+            </div>
             <SiteHeader />
             <main className="flex-1">
-              <div className="mx-auto w-full max-w-6xl px-6 py-12 lg:px-8">
+              <div className="mx-auto w-full max-w-7xl px-5 pb-24 pt-24 sm:px-8 lg:px-12">
                 {children}
               </div>
             </main>

--- a/frontend/app/loading.tsx
+++ b/frontend/app/loading.tsx
@@ -1,0 +1,13 @@
+export default function Loading() {
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center gap-6 text-[color:var(--color-text-primary)]">
+      <div className="loading-reel" role="presentation" />
+      <div className="text-center">
+        <p className="text-xs font-medium uppercase tracking-[0.5em] text-white/65">Priming the ambience engine</p>
+        <p className="mt-2 max-w-sm text-sm text-white/75">
+          Blending crisp white matinee light with oklch(42% .18 15) twilight glow…
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -6,7 +6,7 @@ import { TestimonialGrid } from "@/components/marketing/testimonial-grid"
 
 export default function HomePage() {
   return (
-    <div className="space-y-16">
+    <div className="space-y-20 lg:space-y-28">
       <Hero />
       <FeatureGrid />
       <MetricStrip />

--- a/frontend/components/dashboard/dashboard-layout.tsx
+++ b/frontend/components/dashboard/dashboard-layout.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+import type { ReactNode } from "react"
+import { cn } from "@/lib/utils"
+
+const navigation = [
+  { href: "/dashboard", label: "Overview" },
+  { href: "/rooms", label: "Rooms" },
+  { href: "/library", label: "Library" },
+  { href: "/settings", label: "Settings" },
+]
+
+type DashboardLayoutProps = {
+  children: ReactNode
+}
+
+export function DashboardLayout({ children }: DashboardLayoutProps) {
+  const pathname = usePathname()
+
+  return (
+    <div className="relative flex flex-col gap-10 lg:flex-row">
+      <aside className="w-full rounded-[32px] border border-white/12 bg-[rgba(15,9,46,0.75)] p-6 text-white shadow-[0_35px_120px_rgba(5,3,28,0.55)] lg:sticky lg:top-32 lg:h-fit lg:max-w-[280px]">
+        <div className="space-y-6">
+          <div>
+            <p className="text-xs uppercase tracking-[0.4em] text-white/60">WatchParty</p>
+            <p className="mt-2 text-2xl font-semibold text-white">Host lounge</p>
+            <p className="mt-3 text-sm text-white/70">
+              Manage ambience, schedules, and community cues for every watch night.
+            </p>
+          </div>
+          <nav className="space-y-2 text-sm">
+            {navigation.map((item) => {
+              const isActive = pathname === item.href
+              return (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  className={cn(
+                    "flex items-center justify-between rounded-2xl border border-transparent px-4 py-3 text-white/70 transition-all duration-200",
+                    isActive
+                      ? "border-white/25 bg-white/10 text-white"
+                      : "hover:border-white/15 hover:bg-white/5 hover:text-white",
+                  )}
+                >
+                  <span className="text-sm font-medium uppercase tracking-[0.35em]">{item.label}</span>
+                  <span aria-hidden className="text-xs text-white/40">→</span>
+                </Link>
+              )
+            })}
+          </nav>
+          <div className="rounded-3xl border border-white/12 bg-white/5 p-4 text-xs uppercase tracking-[0.35em] text-white/60">
+            Dual ambience: <span className="ml-2 rounded-full bg-[var(--color-accent-500)] px-3 py-1 text-[#1c0c06]">Auto</span>
+          </div>
+        </div>
+      </aside>
+      <div className="flex-1 space-y-10">
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/frontend/components/layout/site-footer.tsx
+++ b/frontend/components/layout/site-footer.tsx
@@ -1,32 +1,84 @@
 import Link from "next/link"
 
 const footerLinks = [
-  { href: "#features", label: "Platform" },
-  { href: "#metrics", label: "Reliability" },
-  { href: "#testimonials", label: "Customers" },
+  {
+    heading: "Platform",
+    links: [
+      { href: "/about", label: "Story" },
+      { href: "/pricing", label: "Plans" },
+      { href: "#features", label: "Toolkit" },
+    ],
+  },
+  {
+    heading: "Guides",
+    links: [
+      { href: "/guides/watch-night", label: "Watch night" },
+      { href: "#metrics", label: "Impact" },
+      { href: "#testimonials", label: "Community" },
+    ],
+  },
+  {
+    heading: "Product",
+    links: [
+      { href: "/dashboard", label: "Dashboard" },
+      { href: "/rooms", label: "Rooms" },
+      { href: "/library", label: "Library" },
+    ],
+  },
 ]
 
 export function SiteFooter() {
   return (
-    <footer className="border-t border-zinc-800/80 bg-zinc-950/80">
-      <div className="mx-auto flex max-w-6xl flex-col gap-6 px-6 py-10 text-sm text-zinc-500 lg:flex-row lg:items-center lg:justify-between lg:px-8">
-        <div>
-          <p className="font-semibold text-zinc-200">WatchParty</p>
-          <p className="mt-2 max-w-md leading-relaxed">
-            Crafted for teams that want a premium shared viewing experience without the noise. Built with a monochrome palette
-            that lets your stories shine.
-          </p>
+    <footer className="mt-auto border-t border-white/10 bg-[rgba(5,3,20,0.92)]">
+      <div className="relative overflow-hidden">
+        <div className="pointer-events-none absolute -left-32 top-0 h-72 w-72 rounded-full bg-[radial-gradient(circle_at_center,var(--color-sunrise-amber),transparent_65%)] opacity-40 blur-[110px]" />
+        <div className="pointer-events-none absolute -right-16 bottom-[-20%] h-80 w-80 rounded-full bg-[radial-gradient(circle_at_center,rgba(96,70,210,0.65),transparent_65%)] opacity-60 blur-[130px]" />
+        <div className="mx-auto grid w-full max-w-7xl gap-12 px-5 py-16 text-sm text-white/70 sm:px-8 lg:grid-cols-[1.2fr_1fr] lg:px-12">
+          <div className="space-y-8">
+            <div className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/8 px-4 py-1 text-[11px] uppercase tracking-[0.45em] text-white/65">
+              Watch nights
+            </div>
+            <div className="space-y-4">
+              <p className="text-3xl font-semibold text-white">WatchParty</p>
+              <p className="max-w-xl leading-relaxed text-white/75">
+                Calibrate daybreak warmth and midnight glow in seconds. WatchParty is the cinematic operating system for hosts who orchestrate rituals, sync playback, and keep every guest in the same moment.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-3 text-xs uppercase tracking-[0.4em] text-white/55">
+              <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1">Sunrise cues</span>
+              <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1">Dusk ambience</span>
+              <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1">Midnight sync</span>
+            </div>
+            <div className="flex flex-wrap items-center gap-3 rounded-3xl border border-white/10 bg-white/5 p-4 text-xs uppercase tracking-[0.4em] text-white/65 sm:flex-nowrap">
+              <span className="flex items-center gap-2 rounded-full border border-white/15 bg-white/10 px-3 py-1 text-white/70">
+                <span className="h-2 w-2 rounded-full bg-[var(--color-accent-500)] shadow-[0_0_12px_rgba(255,196,150,0.6)]" aria-hidden />
+                Status
+              </span>
+              <span className="flex-1 text-white/70">Scenes ready for tomorrow&apos;s premiere.</span>
+            </div>
+          </div>
+          <div className="grid gap-8 sm:grid-cols-3">
+            {footerLinks.map((section) => (
+              <div key={section.heading} className="space-y-4">
+                <p className="text-xs font-semibold uppercase tracking-[0.42em] text-white/60">
+                  {section.heading}
+                </p>
+                <ul className="space-y-3 text-sm text-white/70">
+                  {section.links.map((item) => (
+                    <li key={item.href}>
+                      <Link href={item.href} className="transition-colors duration-200 hover:text-white">
+                        {item.label}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
         </div>
-        <nav className="flex gap-6">
-          {footerLinks.map((item) => (
-            <Link key={item.href} href={item.href} className="hover:text-zinc-200">
-              {item.label}
-            </Link>
-          ))}
-        </nav>
       </div>
-      <div className="border-t border-zinc-900/80 py-4 text-center text-xs text-zinc-600">
-        © {new Date().getFullYear()} WatchParty Labs. All rights reserved.
+      <div className="border-t border-white/10 px-5 py-6 text-center text-xs text-white/50 sm:px-8 lg:px-12">
+        © {new Date().getFullYear()} WatchParty Labs. Built for crews that never miss a scene.
       </div>
     </footer>
   )

--- a/frontend/components/layout/site-header.tsx
+++ b/frontend/components/layout/site-header.tsx
@@ -2,31 +2,69 @@ import Link from "next/link"
 import { Button } from "@/components/ui/button"
 
 const navigation = [
-  { href: "#features", label: "Features" },
-  { href: "#metrics", label: "Metrics" },
-  { href: "#testimonials", label: "Voices" },
+  { href: "/about", label: "Story" },
+  { href: "/pricing", label: "Plans" },
+  { href: "/guides/watch-night", label: "Guide" },
+  { href: "#features", label: "Toolkit" },
+  { href: "#metrics", label: "Impact" },
+  { href: "#testimonials", label: "Community" },
 ]
 
 export function SiteHeader() {
   return (
-    <header className="border-b border-zinc-800/80 bg-zinc-950/80 backdrop-blur">
-      <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-5 lg:px-8">
-        <Link href="/" className="text-lg font-semibold tracking-tight">
-          WatchParty
-        </Link>
-        <nav className="hidden items-center gap-8 text-sm text-zinc-400 md:flex">
+    <header className="sticky top-0 z-50 flex flex-col gap-3 bg-gradient-to-b from-[rgba(6,3,24,0.85)] via-[rgba(6,3,24,0.55)] to-transparent pb-2 pt-6">
+      <div className="mx-auto w-full max-w-7xl px-5 sm:px-8 lg:px-12">
+        <div className="relative flex items-center justify-between gap-3 rounded-full border border-white/15 bg-[rgba(14,9,36,0.72)] px-4 py-3 shadow-[0_20px_60px_rgba(6,3,24,0.45)] backdrop-blur-2xl sm:px-5">
+          <Link
+            href="/"
+            className="group flex items-center gap-3 rounded-full bg-white/5 px-3 py-1.5 text-sm font-semibold tracking-tight text-white transition-all duration-300 hover:bg-white/10"
+            aria-label="WatchParty home"
+          >
+            <span className="flex h-9 w-9 items-center justify-center rounded-2xl bg-[var(--color-accent-500)] text-xs font-bold uppercase text-[#1b0a09] shadow-[0_16px_40px_rgba(255,196,150,0.45)] transition-transform duration-500 group-hover:-rotate-6 group-hover:scale-105">
+              WP
+            </span>
+            <span className="hidden flex-col leading-none sm:flex">
+              <span className="text-[10px] font-semibold uppercase tracking-[0.45em] text-white/60">
+                Day &amp; night
+              </span>
+              <span className="text-base text-white">WatchParty</span>
+            </span>
+          </Link>
+          <nav className="hidden items-center gap-6 text-[12px] font-medium uppercase tracking-[0.34em] text-white/60 md:flex">
+            {navigation.map((item) => (
+              <Link
+                key={item.href}
+                href={item.href}
+                className="rounded-full px-2 py-1 transition-all duration-200 hover:bg-white/10 hover:text-white"
+              >
+                {item.label}
+              </Link>
+            ))}
+          </nav>
+          <div className="flex items-center gap-2">
+            <div className="hidden items-center gap-1.5 rounded-full border border-white/15 bg-white/5 px-3 py-1 text-[11px] uppercase tracking-[0.45em] text-white/60 sm:flex">
+              <span className="h-2 w-2 rounded-full bg-white/80 shadow-[0_0_12px_rgba(255,255,255,0.7)]" aria-hidden />
+              Live
+            </div>
+            <Button variant="ghost" size="sm" className="hidden md:inline-flex" asChild>
+              <Link href="/about">Inside WatchParty</Link>
+            </Button>
+            <Button size="sm" asChild>
+              <Link href="/dashboard">Launch studio</Link>
+            </Button>
+          </div>
+        </div>
+        <nav className="mt-3 flex gap-3 overflow-x-auto text-[11px] uppercase tracking-[0.45em] text-white/55 md:hidden">
           {navigation.map((item) => (
-            <Link key={item.href} href={item.href} className="hover:text-zinc-50">
+            <Link
+              key={item.href}
+              href={item.href}
+              className="flex-shrink-0 rounded-full border border-white/10 px-3 py-1.5 transition-colors duration-200 hover:border-white/40 hover:text-white"
+            >
               {item.label}
             </Link>
           ))}
         </nav>
-        <div className="flex items-center gap-3">
-          <Button variant="ghost" size="sm">
-            Sign in
-          </Button>
-          <Button size="sm">Launch demo</Button>
-        </div>
       </div>
     </header>
   )

--- a/frontend/components/marketing/call-to-action.tsx
+++ b/frontend/components/marketing/call-to-action.tsx
@@ -1,17 +1,36 @@
+import Link from "next/link"
 import { Button } from "@/components/ui/button"
 
 export function CallToAction() {
   return (
-    <section className="rounded-3xl border border-zinc-800 bg-zinc-900/50 p-10 text-center">
-      <h2 className="text-3xl font-semibold">Ready to host your next watch night?</h2>
-      <p className="mx-auto mt-3 max-w-xl text-sm text-zinc-400">
-        Spin up a room, invite your community, and enjoy a premium cinematic experience in minutes.
-      </p>
-      <div className="mt-6 flex flex-wrap items-center justify-center gap-4">
-        <Button size="lg">Start for free</Button>
-        <Button variant="ghost" size="lg">
-          View pricing
-        </Button>
+    <section className="relative overflow-hidden rounded-[44px] border border-white/12 bg-[rgba(10,6,30,0.82)] px-7 py-16 shadow-[0_60px_150px_rgba(4,2,22,0.6)] sm:px-12 lg:px-20">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.18),transparent_70%)] opacity-70"
+      />
+      <div className="relative flex flex-col gap-10 lg:flex-row lg:items-center lg:justify-between">
+        <div className="max-w-2xl space-y-6">
+          <span className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/10 px-4 py-1 text-[11px] uppercase tracking-[0.45em] text-white/65">
+            Ready to host
+          </span>
+          <h2 className="text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+            Spin up a cinematic watch lounge that transitions from white morning light to twilight glow
+          </h2>
+          <p className="text-base text-white/75">
+            Choose a template, invite your crew, and let WatchParty automate the ambience. Your audience experiences the story in sync whether they join at brunch or stay for the midnight encore.
+          </p>
+        </div>
+        <div className="flex flex-col items-start gap-4 text-sm text-white/75">
+          <Button size="lg" asChild>
+            <Link href="/dashboard">Launch the studio</Link>
+          </Button>
+          <Button variant="secondary" size="lg" asChild>
+            <Link href="/pricing">Compare plans</Link>
+          </Button>
+          <p className="max-w-xs text-xs uppercase tracking-[0.42em] text-white/55">
+            Includes dual ambience presets, spoiler-safe chat, and instant sync invites.
+          </p>
+        </div>
       </div>
     </section>
   )

--- a/frontend/components/marketing/feature-grid.tsx
+++ b/frontend/components/marketing/feature-grid.tsx
@@ -3,26 +3,75 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 
 export function FeatureGrid() {
   return (
-    <section id="features" className="space-y-6">
-      <div className="space-y-3">
-        <h2 className="text-2xl font-semibold">Designed for cinematic clarity</h2>
-        <p className="max-w-2xl text-sm text-zinc-400">
-          Every element is intentionally monochrome, letting bold typography and subtle motion guide guests through your party
-          without distraction.
+    <section id="features" className="space-y-12">
+      <div className="mx-auto max-w-3xl text-center space-y-5">
+        <span className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/8 px-4 py-1 text-[11px] uppercase tracking-[0.45em] text-white/65">
+          Host toolkit
+        </span>
+        <h2 className="text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+          Automate ambience, sync, and storytelling across sunrise briefings and midnight finales
+        </h2>
+        <p className="text-base text-white/75">
+          WatchParty stitches lighting, automations, and co-host collaboration into a single control surface. Build rituals for every time of day and watch the room adapt while the film stays centre stage.
         </p>
       </div>
-      <div className="grid gap-4 sm:grid-cols-2">
-        {features.map((feature) => (
-          <Card key={feature.title}>
-            <CardHeader>
-              <CardTitle>{feature.title}</CardTitle>
-              {feature.highlight ? <span className="text-xs uppercase tracking-[0.2em] text-zinc-400">{feature.highlight}</span> : null}
-            </CardHeader>
-            <CardContent>
-              <CardDescription>{feature.description}</CardDescription>
-            </CardContent>
-          </Card>
-        ))}
+      <div className="grid gap-8 lg:grid-cols-[1.2fr,1fr]">
+        <Card className="relative overflow-hidden border-white/12 bg-[rgba(14,8,40,0.75)]">
+          <div className="absolute inset-0 opacity-70 [mask-image:linear-gradient(to_bottom,black,transparent)]">
+            <div className="h-full w-full bg-[conic-gradient(from_160deg_at_60%_0%,rgba(255,214,170,0.3),rgba(64,40,120,0.45),rgba(255,255,255,0.12))]" />
+          </div>
+          <CardHeader>
+            <CardTitle className="text-2xl">One schedule, two moods</CardTitle>
+            <CardDescription className="text-base text-white/75">
+              Craft a film-night run of show that glides from daylight warmth to nightfall glow. Drag-and-drop cues control lights, overlays, polls, and co-host permissions without touching the stream.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-5 text-sm text-white/80 lg:grid-cols-2">
+            <div className="space-y-3 rounded-3xl border border-white/15 bg-white/5 p-5">
+              <p className="text-sm font-semibold text-white">Scene designer</p>
+              <p className="text-white/70">
+                Lay out sunrise lobbies, intermissions, and encore fireworks. WatchParty automatically pairs each segment with matching ambience and chat settings.
+              </p>
+            </div>
+            <div className="space-y-3 rounded-3xl border border-white/15 bg-white/5 p-5">
+              <p className="text-sm font-semibold text-white">Collaborative hosting</p>
+              <p className="text-white/70">
+                Assign co-host lanes, grant spotlight access, and stage takeovers without breaking the flow. Perfect for panel discussions or creator premieres.
+              </p>
+            </div>
+            <div className="space-y-3 rounded-3xl border border-white/15 bg-white/5 p-5">
+              <p className="text-sm font-semibold text-white">Automated rituals</p>
+              <p className="text-white/70">
+                Countdown cues, lobby soundtracks, and ambient fades trigger right on time so you can focus on the audience.
+              </p>
+            </div>
+            <div className="space-y-3 rounded-3xl border border-white/15 bg-white/5 p-5">
+              <p className="text-sm font-semibold text-white">Audience orchestration</p>
+              <p className="text-white/70">
+                Keep viewers synced with spoiler-safe chat, timed reactions, and polls that inherit the room lighting.
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-1">
+          {features.map((feature) => (
+            <Card key={feature.title} className="border-white/12 bg-[rgba(12,7,36,0.78)]">
+              <CardHeader>
+                <CardTitle className="flex items-start justify-between gap-3 text-xl text-white">
+                  <span>{feature.title}</span>
+                  {feature.highlight ? (
+                    <span className="rounded-full border border-white/15 bg-white/10 px-3 py-1 text-[10px] uppercase tracking-[0.45em] text-white/65">
+                      {feature.highlight}
+                    </span>
+                  ) : null}
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <CardDescription className="text-base text-white/75">{feature.description}</CardDescription>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
       </div>
     </section>
   )

--- a/frontend/components/marketing/hero.tsx
+++ b/frontend/components/marketing/hero.tsx
@@ -1,40 +1,108 @@
+import Link from "next/link"
 import { Button } from "@/components/ui/button"
 
 export function Hero() {
   return (
-    <section className="space-y-10">
-      <div className="space-y-4">
-        <span className="inline-flex items-center gap-2 rounded-full border border-zinc-800 px-4 py-1 text-xs uppercase tracking-[0.3em] text-zinc-400">
-          Premium black & white interface
-        </span>
-        <h1 className="text-4xl font-semibold tracking-tight sm:text-5xl lg:text-6xl">
-          Host unforgettable watch parties without leaving your sofa
-        </h1>
-        <p className="max-w-2xl text-lg text-zinc-400">
-          WatchParty pairs studio-grade synchronisation with a deliberately minimal colour palette so your stories take centre
-          stage. Plan events, guide the conversation, and celebrate together in perfect harmony.
-        </p>
+    <section className="relative overflow-hidden rounded-[56px] border border-white/12 bg-[rgba(12,7,34,0.7)] px-7 py-16 shadow-[0_60px_160px_rgba(5,3,22,0.65)] sm:px-12 lg:px-16">
+      <div className="absolute inset-0 -z-10 opacity-80">
+        <div className="absolute inset-0 bg-[conic-gradient(from_120deg_at_65%_35%,rgba(255,255,255,0.2),rgba(255,204,164,0.35),rgba(58,34,108,0.45),rgba(255,255,255,0.12))]" />
+        <div className="grid-overlay" />
       </div>
-      <div className="flex flex-wrap items-center gap-4">
-        <Button size="lg">Create a party</Button>
-        <Button variant="ghost" size="lg">
-          Explore the interface
-        </Button>
+      <div className="relative grid gap-14 lg:grid-cols-[1.45fr,1fr] lg:items-center">
+        <div className="space-y-10">
+          <div className="flex flex-wrap items-center gap-4">
+            <span className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/10 px-4 py-1 text-[11px] uppercase tracking-[0.45em] text-white/70">
+              Cinema OS
+            </span>
+            <span className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/5 px-4 py-1 text-[11px] uppercase tracking-[0.45em] text-white/60">
+              Sunrise ↔ Midnight
+            </span>
+          </div>
+          <div className="space-y-6">
+            <h1 className="text-4xl font-semibold tracking-tight text-white sm:text-5xl lg:text-6xl">
+              Design sunrise premieres and midnight encores without rebuilding the room
+            </h1>
+            <p className="max-w-2xl text-lg text-white/75">
+              WatchParty balances white room brightness with oklch(42% .18 15) twilight accents. Cue lighting, automate rituals, and keep every guest perfectly in sync no matter the timezone.
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-4">
+            <Button size="lg" asChild>
+              <Link href="/pricing">Plan your night</Link>
+            </Button>
+            <Button variant="secondary" size="lg" asChild>
+              <Link href="#features">Preview the toolkit</Link>
+            </Button>
+          </div>
+          <dl className="grid gap-5 sm:grid-cols-3">
+            <div className="rounded-3xl border border-white/12 bg-white/5 p-5 text-white/80">
+              <dt className="text-xs uppercase tracking-[0.32em] text-white/60">Preset palettes</dt>
+              <dd className="mt-2 text-3xl font-semibold text-white">42 scenes</dd>
+              <dd className="mt-2 text-xs text-white/60">Sunrise, dusk, neon, and after-party lighting in one tap.</dd>
+            </div>
+            <div className="rounded-3xl border border-white/12 bg-white/5 p-5 text-white/80">
+              <dt className="text-xs uppercase tracking-[0.32em] text-white/60">Sync drift</dt>
+              <dd className="mt-2 text-3xl font-semibold text-white">±18 ms</dd>
+              <dd className="mt-2 text-xs text-white/60">Frame-perfect playback even when guests jump between scenes.</dd>
+            </div>
+            <div className="rounded-3xl border border-white/12 bg-white/5 p-5 text-white/80">
+              <dt className="text-xs uppercase tracking-[0.32em] text-white/60">Hosts onboarded</dt>
+              <dd className="mt-2 text-3xl font-semibold text-white">11k / mo</dd>
+              <dd className="mt-2 text-xs text-white/60">Festival crews, classrooms, and fandom clubs in 62 countries.</dd>
+            </div>
+          </dl>
+        </div>
+        <div className="relative mx-auto w-full max-w-md">
+          <div className="absolute inset-0 -z-10 rounded-[40px] bg-[rgba(255,255,255,0.08)] blur-3xl" aria-hidden />
+          <div className="relative overflow-hidden rounded-[40px] border border-white/12 bg-[rgba(16,9,46,0.78)] p-7 text-white shadow-[0_45px_140px_rgba(6,3,30,0.6)]">
+            <header className="flex items-center justify-between gap-4 text-xs uppercase tracking-[0.4em] text-white/60">
+              <span>Scene timeline</span>
+              <span className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/5 px-3 py-1">
+                Dual ambience
+              </span>
+            </header>
+            <div className="mt-7 space-y-6">
+              <div className="grid gap-5 sm:grid-cols-2">
+                <div className="relative overflow-hidden rounded-[28px] border border-white/15 bg-white text-[#1c1035] shadow-[0_20px_55px_rgba(255,255,255,0.28)]">
+                  <div className="absolute inset-0 bg-[radial-gradient(circle_at_85%_20%,rgba(255,204,164,0.55),transparent_60%)]" />
+                  <div className="relative space-y-3 p-5">
+                    <p className="text-xs font-semibold uppercase tracking-[0.32em]">08:15</p>
+                    <p className="text-sm font-medium text-[#4b366c]">Sunrise premiere lobby</p>
+                    <p className="text-xs text-[#5f4983]">Warm white lighting, stretch goals board, ambient vinyl.</p>
+                  </div>
+                </div>
+                <div className="relative overflow-hidden rounded-[28px] border border-white/15 bg-[radial-gradient(circle_at_top,rgba(27,16,72,0.85),rgba(5,3,20,0.95))] text-white shadow-[0_28px_65px_rgba(16,10,60,0.6)]">
+                  <div className="absolute inset-0 bg-[radial-gradient(circle_at_25%_25%,rgba(111,82,255,0.4),transparent_60%)]" />
+                  <div className="relative space-y-3 p-5">
+                    <p className="text-xs font-semibold uppercase tracking-[0.32em] text-white/70">23:45</p>
+                    <p className="text-sm font-medium text-white/85">Midnight encore</p>
+                    <p className="text-xs text-white/70">Neon accents, spoiler-safe reactions, spotlight co-host.</p>
+                  </div>
+                </div>
+              </div>
+              <div className="grid gap-4 rounded-[28px] border border-white/12 bg-white/5 p-5 text-sm text-white/80">
+                <p className="text-xs uppercase tracking-[0.32em] text-white/60">Tonight&apos;s rituals</p>
+                <ul className="space-y-2">
+                  <li>• Fade lobby soundtrack as countdown hits 30 seconds.</li>
+                  <li>• Auto dim smart lights when film opens.</li>
+                  <li>• Trigger midnight neon overlay for encore reactions.</li>
+                </ul>
+              </div>
+              <div className="grid gap-3 rounded-[24px] border border-white/12 bg-white/5 p-5 text-xs uppercase tracking-[0.32em] text-white/60">
+                <div className="flex items-center justify-between gap-3 text-[color:var(--color-text-muted)]">
+                  <span className="rounded-full border border-white/15 bg-white/10 px-3 py-1 text-[11px] text-white/70">
+                    Auto cues
+                  </span>
+                  <span className="text-white">Ready</span>
+                </div>
+                <div className="h-2 rounded-full bg-white/10">
+                  <div className="h-full rounded-full bg-[var(--color-accent-500)]" style={{ width: "86%" }} />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
-      <dl className="grid gap-4 sm:grid-cols-3">
-        <div className="rounded-2xl border border-zinc-800/80 bg-zinc-900/40 p-6">
-          <dt className="text-sm text-zinc-400">Stream in sync</dt>
-          <dd className="mt-2 text-3xl font-semibold">±50ms drift</dd>
-        </div>
-        <div className="rounded-2xl border border-zinc-800/80 bg-zinc-900/40 p-6">
-          <dt className="text-sm text-zinc-400">Curated playlists</dt>
-          <dd className="mt-2 text-3xl font-semibold">+1k templates</dd>
-        </div>
-        <div className="rounded-2xl border border-zinc-800/80 bg-zinc-900/40 p-6">
-          <dt className="text-sm text-zinc-400">Collaborative chat</dt>
-          <dd className="mt-2 text-3xl font-semibold">Realtime emoji & polls</dd>
-        </div>
-      </dl>
     </section>
   )
 }

--- a/frontend/components/marketing/metric-strip.tsx
+++ b/frontend/components/marketing/metric-strip.tsx
@@ -2,15 +2,39 @@ import { metrics } from "@/lib/data/home"
 
 export function MetricStrip() {
   return (
-    <section id="metrics" className="rounded-3xl border border-zinc-800/70 bg-zinc-900/40 p-6">
-      <div className="grid gap-6 sm:grid-cols-3">
-        {metrics.map((metric) => (
-          <div key={metric.label} className="space-y-2">
-            <p className="text-xs uppercase tracking-[0.2em] text-zinc-500">{metric.label}</p>
-            <p className="text-3xl font-semibold text-zinc-50">{metric.value}</p>
-            <p className="text-sm text-zinc-400">{metric.description}</p>
-          </div>
-        ))}
+    <section
+      id="metrics"
+      className="relative overflow-hidden rounded-[44px] border border-white/12 bg-[rgba(10,6,30,0.8)] px-6 py-12 shadow-[0_55px_150px_rgba(4,2,20,0.6)] sm:px-10"
+    >
+      <div
+        aria-hidden
+        className="pointer-events-none absolute -left-24 top-1/2 h-72 w-72 -translate-y-1/2 rounded-full bg-[radial-gradient(circle_at_center,rgba(255,214,170,0.45),transparent_65%)] opacity-60 blur-[120px]"
+      />
+      <div
+        aria-hidden
+        className="pointer-events-none absolute -right-24 top-1/2 h-72 w-72 -translate-y-1/2 rounded-full bg-[radial-gradient(circle_at_center,rgba(88,62,210,0.55),transparent_60%)] opacity-60 blur-[140px]"
+      />
+      <div className="relative grid gap-12 lg:grid-cols-[1.2fr,1fr] lg:items-center">
+        <div className="space-y-5">
+          <span className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/10 px-4 py-1 text-[11px] uppercase tracking-[0.45em] text-white/65">
+            Proof in the glow
+          </span>
+          <h2 className="text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+            Thousands of hosts rely on WatchParty to run seamless days that end in luminous nights
+          </h2>
+          <p className="text-base text-white/75">
+            WatchParty&apos;s sync engine and ambience presets power film festivals, esports leagues, and classroom screenings. Here&apos;s what crews experience after switching from DIY setups.
+          </p>
+        </div>
+        <div className="grid gap-6 sm:grid-cols-3">
+          {metrics.map((metric) => (
+            <div key={metric.label} className="rounded-3xl border border-white/12 bg-white/5 p-6 text-white/80">
+              <p className="text-xs uppercase tracking-[0.36em] text-white/60">{metric.label}</p>
+              <p className="mt-3 text-3xl font-semibold text-white">{metric.value}</p>
+              <p className="mt-3 text-sm text-white/70">{metric.description}</p>
+            </div>
+          ))}
+        </div>
       </div>
     </section>
   )

--- a/frontend/components/marketing/testimonial-grid.tsx
+++ b/frontend/components/marketing/testimonial-grid.tsx
@@ -3,27 +3,53 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 
 export function TestimonialGrid() {
   return (
-    <section id="testimonials" className="space-y-6">
-      <div className="space-y-3">
-        <h2 className="text-2xl font-semibold">Trusted for premiers, tournaments, and co-streams</h2>
-        <p className="max-w-2xl text-sm text-zinc-400">
-          Hear how creators keep their communities engaged with WatchParty&apos;s resilient streaming and elegant presentation.
+    <section id="testimonials" className="space-y-12">
+      <div className="mx-auto max-w-3xl text-center space-y-5">
+        <span className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/8 px-4 py-1 text-[11px] uppercase tracking-[0.45em] text-white/65">
+          Community glow
+        </span>
+        <h2 className="text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+          From festival premieres to campus marathons, crews feel the theatre energy return
+        </h2>
+        <p className="text-base text-white/75">
+          Hosts swap screen shares for rituals that respect the story. These testimonials cover the sunrise lobby greetings and midnight encore cheers that WatchParty now automates.
         </p>
       </div>
-      <div className="grid gap-4 sm:grid-cols-3">
-        {testimonials.map((item) => (
-          <Card key={item.author}>
-            <CardHeader>
-              <CardTitle className="text-base font-semibold text-zinc-100">{item.author}</CardTitle>
-              <span className="text-xs text-zinc-500">{item.role}</span>
-            </CardHeader>
-            <CardContent>
-              <CardDescription className="text-sm leading-relaxed text-zinc-300">
-                “{item.message}”
-              </CardDescription>
-            </CardContent>
-          </Card>
-        ))}
+      <div className="grid gap-8 lg:grid-cols-[1.2fr,1fr]">
+        <Card className="relative overflow-hidden border-white/12 bg-[rgba(14,8,40,0.78)]">
+          <div className="absolute inset-0 opacity-80 [mask-image:linear-gradient(to_bottom,black,transparent)]">
+            <div className="h-full w-full bg-[conic-gradient(from_180deg_at_70%_0%,rgba(255,214,170,0.28),rgba(54,32,112,0.45),rgba(255,255,255,0.12))]" />
+          </div>
+          <CardHeader>
+            <CardTitle className="text-2xl">“We stopped troubleshooting and started hosting”</CardTitle>
+            <CardDescription className="text-base text-white/75">
+              WatchParty keeps lighting, sync, and chat rituals aligned. Clubs now focus on conversation while the ambience engine glides from daybreak intros to midnight finales.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6 text-white/80">
+            <blockquote className="rounded-3xl border border-white/15 bg-white/5 p-6 text-base leading-relaxed text-white/85">
+              “Guests swear they can feel the lighting change rooms with them. The lobby music fades, captions stay sharp, and the encore glow arrives right on time.”
+            </blockquote>
+            <div className="flex flex-wrap gap-3 text-xs uppercase tracking-[0.42em] text-white/60">
+              <span className="rounded-full border border-white/15 bg-white/10 px-3 py-1">Festival hosts</span>
+              <span className="rounded-full border border-white/15 bg-white/10 px-3 py-1">Campus clubs</span>
+              <span className="rounded-full border border-white/15 bg-white/10 px-3 py-1">Creator premieres</span>
+            </div>
+          </CardContent>
+        </Card>
+        <div className="grid gap-6">
+          {testimonials.map((testimonial) => (
+            <Card key={testimonial.author} className="border-white/12 bg-[rgba(12,7,36,0.78)]">
+              <CardHeader>
+                <CardTitle className="text-lg text-white">{testimonial.author}</CardTitle>
+                <p className="text-xs uppercase tracking-[0.42em] text-white/60">{testimonial.role}</p>
+              </CardHeader>
+              <CardContent>
+                <CardDescription className="text-base text-white/75">{testimonial.message}</CardDescription>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
       </div>
     </section>
   )

--- a/frontend/components/ui/button.tsx
+++ b/frontend/components/ui/button.tsx
@@ -8,18 +8,21 @@ import { cn } from "@/lib/utils"
 type ButtonElement = HTMLButtonElement
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium transition-colors",
+  "inline-flex items-center justify-center gap-2 rounded-full text-sm font-semibold transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent",
   {
     variants: {
       variant: {
-        primary: "bg-zinc-50 text-zinc-900 hover:bg-zinc-200",
-        secondary: "bg-zinc-900 text-zinc-50 ring-1 ring-inset ring-zinc-700 hover:bg-zinc-800",
-        ghost: "bg-transparent text-zinc-50 hover:bg-zinc-900/60",
+        primary:
+          "relative overflow-hidden bg-[var(--color-accent-500)] text-[#1c0c06] shadow-[0_20px_60px_rgba(255,194,140,0.55)] transition-transform duration-300 before:absolute before:inset-0 before:bg-[radial-gradient(circle_at_30%_20%,rgba(255,255,255,0.4),transparent_60%)] before:opacity-0 before:transition-opacity before:duration-300 hover:-translate-y-0.5 hover:shadow-[0_26px_70px_rgba(255,194,140,0.65)] hover:before:opacity-100 focus-visible:ring-white/70",
+        secondary:
+          "border border-white/20 bg-white/10 text-white shadow-[0_14px_40px_rgba(12,8,45,0.45)] backdrop-blur-md hover:border-white/35 hover:bg-white/14",
+        ghost:
+          "bg-transparent text-white/70 hover:bg-white/10 hover:text-white",
       },
       size: {
-        default: "h-10 px-4",
-        sm: "h-8 px-3 text-xs",
-        lg: "h-12 px-6 text-base",
+        default: "h-10 px-5",
+        sm: "h-8 px-4 text-xs",
+        lg: "h-12 px-7 text-base",
       },
     },
     defaultVariants: {

--- a/frontend/components/ui/card.tsx
+++ b/frontend/components/ui/card.tsx
@@ -16,26 +16,37 @@ type CardFooterProps = HTMLAttributes<HTMLDivElement>
 export function Card({ className, ...props }: CardProps) {
   return (
     <div
-      className={cn("rounded-2xl border border-zinc-800 bg-zinc-900/60 p-6 shadow-sm", className)}
+      className={cn(
+        "card-sheen rounded-[32px] border border-white/12 bg-[rgba(10,6,30,0.78)] p-8 text-[color:var(--color-text-primary)] shadow-[0_34px_90px_rgba(5,4,28,0.6)] backdrop-blur-2xl transition-transform duration-500 hover:-translate-y-1 hover:border-white/25 hover:bg-[rgba(16,10,44,0.82)]",
+        className,
+      )}
       {...props}
     />
   )
 }
 
 export function CardHeader({ className, ...props }: CardHeaderProps) {
-  return <div className={cn("mb-4 space-y-2", className)} {...props} />
+  return <div className={cn("mb-5 space-y-3", className)} {...props} />
 }
 
 export function CardTitle({ className, ...props }: CardTitleProps) {
-  return <h3 className={cn("text-lg font-semibold", className)} {...props} />
+  return <h3 className={cn("text-xl font-semibold tracking-tight text-white", className)} {...props} />
 }
 
 export function CardDescription({ className, ...props }: CardDescriptionProps) {
-  return <p className={cn("text-sm text-zinc-400", className)} {...props} />
+  return (
+    <p
+      className={cn(
+        "text-sm leading-relaxed text-[color:var(--color-text-muted)]",
+        className,
+      )}
+      {...props}
+    />
+  )
 }
 
 export function CardContent({ className, ...props }: CardContentProps) {
-  return <div className={cn("space-y-4", className)} {...props} />
+  return <div className={cn("space-y-5", className)} {...props} />
 }
 
 export function CardFooter({ className, ...props }: CardFooterProps) {

--- a/frontend/lib/data/home.ts
+++ b/frontend/lib/data/home.ts
@@ -18,58 +18,66 @@ export type Testimonial = {
 
 export const features: Feature[] = [
   {
-    title: "Crystal-clear synchronisation",
+    title: "Ambient palette switcher",
     description:
-      "Enjoy films, series, and livestreams together with automatic playback syncing and resilient network recovery.",
-    highlight: "Sync that never drifts",
+      "Pair crisp daytime whites with twilight indigos using a single slider. WatchParty remembers which cues belong to sunrise lobbies or midnight encores and swaps them instantly.",
+    highlight: "Sunrise → midnight",
   },
   {
-    title: "Cinematic presentation",
+    title: "Director’s stage manager",
     description:
-      "A monochrome interface that keeps the focus on your content while surfacing party chat, polls, and reactions when you need them.",
+      "Trigger countdowns, lighting changes, and spotlight transitions from one schedule. Every change respects captions and the primary frame, even during encore reactions.",
+    highlight: "Live scripting",
   },
   {
-    title: "Planning tools",
+    title: "Guided arrivals",
     description:
-      "Coordinate across time zones, share curated playlists, and collect RSVP responses without leaving the experience.",
+      "Pre-show soundtracks, host notes, and check-ins roll out automatically so guests join a polished lobby rather than a blank screen.",
+    highlight: "Lobby rituals",
+  },
+  {
+    title: "Community overlays",
+    description:
+      "Spoiler-safe chat lanes, timed polls, and reaction bursts fade with the next scene. Your audience stays expressive without losing sync.",
+    highlight: "Quiet sync chat",
   },
 ]
 
 export const metrics: Metric[] = [
   {
-    label: "Monthly parties hosted",
-    value: "12k+",
-    description: "Communities rely on WatchParty to premiere episodes and host film clubs every week.",
+    label: "Rooms orchestrated monthly",
+    value: "24k hosts",
+    description: "Film clubs, classrooms, and creator collectives run sunrise briefings and midnight finales on the same dashboard.",
   },
   {
-    label: "Average satisfaction",
-    value: "4.9 / 5",
-    description: "Post-party surveys show consistently high ratings for video quality and ease of use.",
+    label: "Average sync drift",
+    value: "±18 ms",
+    description: "Frame-perfect playback even when audiences scrub, pause, or rejoin after connection blips.",
   },
   {
-    label: "Set-up time",
-    value: "< 2 minutes",
-    description: "From invitation to start time, hosts launch an event faster than brewing popcorn.",
+    label: "Setup time saved",
+    value: "72%",
+    description: "Templates, ambience presets, and auto-invites get the show rolling before the trailers end.",
   },
 ]
 
 export const testimonials: Testimonial[] = [
   {
-    author: "Jordan Michaels",
-    role: "Community manager, FlickStream",
+    author: "Maya Castillo",
+    role: "Festival host",
     message:
-      "The black and white aesthetic keeps our festivals feeling premium, and the sync tech just works even when viewers join late.",
+      "Our premieres glide from daylight Q&As to neon encores without rebuilding scenes. WatchParty keeps lighting, chat, and sync exactly where we need them.",
   },
   {
-    author: "Priya Das",
-    role: "Indie filmmaker",
+    author: "Arjun Patel",
+    role: "University film society",
     message:
-      "Hosting premieres with WatchParty means I can focus on chatting with fans instead of troubleshooting stream issues.",
+      "Students join from dorms at sunrise and stay for midnight retrospectives. Automations handle the transitions so we can focus on discussion.",
   },
   {
-    author: "Liam Chen",
-    role: "Esports commentator",
+    author: "Sophie Lin",
+    role: "Streaming curator",
     message:
-      "We co-stream tournaments with zero playback drift. The real-time poll overlays are a huge hit with our audience.",
+      "Tens of thousands of fans react in the same beat. The dual ambience presets let us theme each act without sacrificing precision sync.",
   },
 ]

--- a/frontend/tests/home.test.tsx
+++ b/frontend/tests/home.test.tsx
@@ -5,15 +5,15 @@ describe("HomePage", () => {
   it("renders hero content", () => {
     render(<HomePage />)
 
-    expect(screen.getByText(/Host unforgettable watch parties/i)).toBeInTheDocument()
-    expect(screen.getByText(/Create a party/i)).toBeInTheDocument()
+    expect(screen.getByText(/Design sunrise premieres/i)).toBeInTheDocument()
+    expect(screen.getByText(/Plan your night/i)).toBeInTheDocument()
   })
 
   it("lists platform metrics", () => {
     render(<HomePage />)
 
-    expect(screen.getByText("12k+")).toBeInTheDocument()
-    expect(screen.getByText("4.9 / 5")).toBeInTheDocument()
-    expect(screen.getByText(/Set-up time/i)).toBeInTheDocument()
+    expect(screen.getByText("24k hosts")).toBeInTheDocument()
+    expect(screen.getAllByText("±18 ms").length).toBeGreaterThan(0)
+    expect(screen.getByText(/Setup time saved/i)).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- refresh the global day-to-night palette, background overlays, and loading states to lean into the new cinematic theme
- rebuild the marketing hero, feature, metric, testimonial, and CTA sections alongside updated content data and tests
- restyle supporting pages and dashboard metrics to align with the dual ambience story across screen sizes

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_b_68d938e798d48328afbedd94db3bdece