### PR TITLE
chore: add workflow to collect service logs

### DIFF
--- a/.github/workflows/collect-service-logs.yml
+++ b/.github/workflows/collect-service-logs.yml
@@ -1,0 +1,41 @@
+name: Collect service logs
+
+on:
+  workflow_dispatch:
+
+jobs:
+  collect-logs:
+    name: Collect Docker service logs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Prepare logs directory
+        run: |
+          rm -rf logs
+          mkdir -p logs
+
+      - name: Start services
+        run: |
+          docker compose pull
+          docker compose up -d
+
+      - name: Capture service logs
+        run: |
+          services=$(docker compose config --services)
+          for service in $services; do
+            echo "Collecting logs for ${service}"
+            docker compose logs --no-color "$service" > "logs/${service}.log"
+          done
+
+      - name: Shut down services
+        if: always()
+        run: docker compose down
+
+      - name: Upload logs archive
+        uses: actions/upload-artifact@v3
+        with:
+          name: service-logs
+          path: logs
+          if-no-files-found: error

--- a/frontend/mock-data.md
+++ b/frontend/mock-data.md
@@ -7,32 +7,76 @@
 
 ## frontend/app/(public)/pricing/page.tsx
 - `plans`: array of tier descriptors for Matinee, Premiere, Marathon including price, perks list, and CTA links.
+- Hero banner copy with pricing badges describing "Plans that scale" messaging.
+- FAQ card grid with four hard-coded Q&A entries on ambience switching, branding, host failover, and education discount.
 
 ## frontend/app/(public)/guides/watch-night/page.tsx
 - `steps`: onboarding ritual phases covering tone setup, invites, staging segments, going live.
 - `tips`: signature ritual suggestions like dawn warm-up, intermission ritual, midnight encore.
+- Hero introduction text positioning the ritual guide plus checklist bullet points for pre-show tasks.
 
 ## frontend/app/(public)/about/page.tsx
 - `timeline`: company history milestones for years 2020, 2021, 2023 with narrative descriptions.
+- Hero section copy highlighting WatchParty's mission and CTA buttons.
+- Principle cards outlining ambience, host flow, and community rituals alongside a static metrics card of watch nights, rating, and countries.
 
 ## frontend/app/(dashboard)/dashboard/page.tsx
 - `highlights`: dashboard stat cards for upcoming watch nights, RSVPs, automation cues.
 - `timeline`: daily schedule entries with time, title, and ambience notes.
+- Hero welcome text detailing ambience automation status indicators.
+- Crew notes card with three fixed reminders for lighting, co-hosts, and sponsors.
 
 ## frontend/app/(dashboard)/rooms/page.tsx
 - `rooms`: watch lounge cards with name, theme, status, and playlist details for three sample rooms.
+- Introductory copy encouraging hosts to manage ambience and co-host rosters.
 
 ## frontend/app/(dashboard)/settings/page.tsx
 - `preferences`: settings cards covering ambience defaults, crew permissions, notification messaging.
+- Integrations card listing static partner categories for lighting, streaming, and community tools.
 
 ## frontend/app/(dashboard)/library/page.tsx
 - `media`: library entries for Aurora Skies, Rift Legends, Midnight Stories with type, duration, ambience tags.
+- Header description explaining how to curate watch night catalogues.
 
 ## frontend/components/dashboard/dashboard-layout.tsx
 - `navigation`: client-side menu definitions for overview, rooms, library, and settings routes.
+- Sidebar tagline describing the "Host lounge" and dual ambience status pill.
 
 ## frontend/components/layout/site-footer.tsx
 - `footerLinks`: footer sections with headings and navigation items for Platform, Guides, Product.
+- Footer hero copy describing WatchParty, ambience badges, and status pill text.
 
 ## frontend/components/layout/site-header.tsx
 - `navigation`: marketing header links for Story, Plans, Guide, Toolkit, Impact, Community anchors.
+- Static hero badge trio ("Day & night", "Live") and CTAs for Inside WatchParty / Launch studio.
+
+## frontend/components/marketing/hero.tsx
+- Hard-coded hero badges, headline, and descriptive paragraph describing WatchParty's ambience automation.
+- Stats trio for preset palettes, sync drift, and hosts onboarded plus timeline cards for sunrise lobby and midnight encore.
+- Ritual checklist listing tonight's rituals and auto cues progress meter.
+
+## frontend/components/marketing/feature-grid.tsx
+- Host toolkit heading, subtitle, and descriptive paragraphs for the primary feature card.
+- Four static callout cards covering scene designer, collaborative hosting, automated rituals, and audience orchestration.
+
+## frontend/components/marketing/metric-strip.tsx
+- Intro copy under "Proof in the glow" describing host adoption.
+- Background badges and descriptive paragraph complementing metrics pulled from `@/lib/data/home`.
+
+## frontend/components/marketing/testimonial-grid.tsx
+- Section framing text under "Community glow".
+- Spotlight testimonial card copy and audience badge trio preceding the mapped testimonial data.
+
+## frontend/components/marketing/call-to-action.tsx
+- CTA banner badges, headline, descriptive paragraph, and buttons linking to dashboard/pricing.
+- Supporting caption summarizing included features beneath the buttons.
+
+## frontend/app/layout.tsx
+- `metadata` export establishing default site title template and marketing description.
+- Layout wrapper includes static decorative overlays for ambience context.
+
+## frontend/app/loading.tsx
+- Loading screen copy: uppercase status line and descriptive sentence about blending ambience.
+
+## frontend/app/api/health/route.ts
+- JSON response with static `status: "ok"` and `service: "watch-party-frontend"` payload for health checks.

--- a/frontend/no-api-pages.md
+++ b/frontend/no-api-pages.md
@@ -1,0 +1,25 @@
+# Frontend routes without API requests
+
+This audit covers every Next.js page, layout, and loading state under `frontend/app` as well as the dashboard layout wrapper. None of these surfaces perform client-side or server-side API requests; all data is hard-coded in the component files or imported from local static modules like `@/lib/data/home`.
+
+## Marketing routes (`app/(public)` and root)
+- `/` – `app/page.tsx` renders marketing sections that only read static testimonial and feature data from `@/lib/data/home` and local constants. No data fetching hooks or `fetch` calls are present.
+- `/about` – `app/(public)/about/page.tsx` relies on inline arrays for the company timeline and design principles.
+- `/pricing` – `app/(public)/pricing/page.tsx` defines the pricing plans and FAQ copy in local constants.
+- `/guides/watch-night` – `app/(public)/guides/watch-night/page.tsx` sources the guide steps and signature rituals from in-file arrays.
+
+Shared marketing chrome (`app/layout.tsx`, `components/layout/site-header.tsx`, `components/layout/site-footer.tsx`, and `components/providers.tsx`) also avoids API calls. Navigation links and hero copy are statically defined.
+
+## Dashboard routes (`app/(dashboard)`)
+- `/dashboard` – `app/(dashboard)/dashboard/page.tsx` renders overview highlights, timelines, and crew notes from static arrays.
+- `/rooms` – `app/(dashboard)/rooms/page.tsx` lists room cards using a locally declared `rooms` array.
+- `/library` – `app/(dashboard)/library/page.tsx` displays media items defined in a constant.
+- `/settings` – `app/(dashboard)/settings/page.tsx` shows preferences and integrations defined inline.
+
+The dashboard route group layout (`app/(dashboard)/layout.tsx` and `components/dashboard/dashboard-layout.tsx`) determines active navigation with `usePathname` but does not perform any data fetching.
+
+## Global loading state
+- `app/loading.tsx` renders a branded loading screen without performing network activity.
+
+## API routes for reference
+The only API route present is `app/api/health/route.ts`, which returns a static JSON payload. No page or component invokes it during render.

--- a/logs/README.md
+++ b/logs/README.md
@@ -1,0 +1,5 @@
+# Service Log Archives
+
+This directory is reserved for runtime log snapshots produced by the CI log collection workflow. The workflow clears any existing contents before gathering fresh logs so that each run captures a clean, current set of service logs.
+
+Log files are named after the service they represent (for example, `backend.log`, `frontend.log`, `nginx.log`, etc.).


### PR DESCRIPTION
## Summary
- create a tracked logs directory for storing captured service log snapshots
- add a workflow_dispatch job that rebuilds services, refreshes logs, and uploads them as artifacts

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_b_68db2afb84408328a66e32664b1ac673