### PR TITLE
Update artifact upload action in service logs workflow

### DIFF
--- a/.github/workflows/collect-service-logs.yml
+++ b/.github/workflows/collect-service-logs.yml
@@ -34,7 +34,7 @@ jobs:
         run: docker compose down
 
       - name: Upload logs archive
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: service-logs
           path: logs


### PR DESCRIPTION
## Summary
- update the collect-service-logs workflow to use `actions/upload-artifact@v4`

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_b_68db319dbbec8328bc2a4f02ec83a8d4