### PR TITLE
Fix service logs workflow environment and build steps

### DIFF
--- a/.github/workflows/collect-service-logs.yml
+++ b/.github/workflows/collect-service-logs.yml
@@ -16,10 +16,20 @@ jobs:
           rm -rf logs
           mkdir -p logs
 
-      - name: Start services
+      - name: Prepare environment files
         run: |
-          docker compose pull
-          docker compose up -d
+          if [ ! -f backend/.env ] && [ -f backend/.env.example ]; then
+            cp backend/.env.example backend/.env
+          fi
+          if [ ! -f frontend/.env.local ] && [ -f frontend/.env.example ]; then
+            cp frontend/.env.example frontend/.env.local
+          fi
+
+      - name: Build images
+        run: docker compose build backend frontend
+
+      - name: Start services
+        run: docker compose up -d
 
       - name: Capture service logs
         run: |
@@ -34,7 +44,7 @@ jobs:
         run: docker compose down
 
       - name: Upload logs archive
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: service-logs
           path: logs


### PR DESCRIPTION
## Summary
- add a step to generate backend and frontend environment files for the log collection workflow
- build the backend and frontend images before starting services to avoid registry pull failures

## Testing
- not run (workflow change)

------
https://chatgpt.com/codex/tasks/task_b_68db319dbbec8328bc2a4f02ec83a8d4