### PR TITLE
Capture logs from running compose services

### DIFF
--- a/.github/workflows/collect-service-logs.yml
+++ b/.github/workflows/collect-service-logs.yml
@@ -16,25 +16,20 @@ jobs:
           rm -rf logs
           mkdir -p logs
 
-      - name: Start services
+      - name: Collect logs from running services
         run: |
-          docker compose pull
-          docker compose up -d
-
-      - name: Capture service logs
-        run: |
-          services=$(docker compose config --services)
+          services=$(docker compose ps --services --filter "status=running")
+          if [ -z "$services" ]; then
+            echo "No running services found for docker compose project"
+            exit 1
+          fi
           for service in $services; do
-            echo "Collecting logs for ${service}"
-            docker compose logs --no-color "$service" > "logs/${service}.log"
+            echo "Collecting logs for ${service}" \
+              && docker compose logs --no-color "$service" > "logs/${service}.log"
           done
 
-      - name: Shut down services
-        if: always()
-        run: docker compose down
-
       - name: Upload logs archive
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: service-logs
           path: logs


### PR DESCRIPTION
## Summary
- simplify the service log workflow to only read logs from services that are already running
- fail fast when no running docker compose services are detected to avoid empty artifacts

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_b_68db319dbbec8328bc2a4f02ec83a8d4