### PR TITLE
Fix analytics regression tests bootstrap and Google Drive profile lookup

### DIFF
--- a/backend/apps/analytics/tests/__init__.py
+++ b/backend/apps/analytics/tests/__init__.py
@@ -1,0 +1,37 @@
+"""Ensure Django is configured before importing analytics tests.
+
+Pytest collects tests from the ``apps`` package directly, which means the
+bootstrap logic that lives in the top-level ``tests`` package is bypassed for
+these modules.  When the test runner tries to import the DRF ``APITestCase``
+without Django being set up we get an ``ImproperlyConfigured`` error.  To keep
+the analytics regression tests self-contained we mirror the bootstrap logic
+here so that Django is always configured prior to importing the test modules.
+"""
+
+import importlib
+import os
+import sys
+from pathlib import Path
+
+import django
+from django.apps import apps as django_apps
+from django.core.management import call_command
+from django.db import connections
+
+BASE_DIR = Path(__file__).resolve().parents[3]
+if str(BASE_DIR) not in sys.path:
+    sys.path.insert(0, str(BASE_DIR))
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings.testing')
+
+if not django_apps.ready:
+    django.setup()
+
+default_connection = connections['default']
+existing_tables = set(default_connection.introspection.table_names())
+
+if 'authentication_user' not in existing_tables:
+    call_command('migrate', run_syncdb=True, interactive=False, verbosity=0)
+
+alias_target = importlib.import_module(f'{__name__}.dashboard_views_regression')
+sys.modules.setdefault('tests.test_dashboard_views', alias_target)

--- a/backend/apps/analytics/tests/dashboard_views_regression.py
+++ b/backend/apps/analytics/tests/dashboard_views_regression.py
@@ -1,9 +1,10 @@
 from datetime import timedelta
 
+from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
 from rest_framework import status
-from rest_framework.test import APITestCase
+from rest_framework.test import APIClient
 
 from apps.analytics.models import AnalyticsEvent
 from apps.authentication.models import User
@@ -11,8 +12,10 @@ from apps.parties.models import WatchParty
 from apps.videos.models import Video
 
 
-class DashboardViewsTests(APITestCase):
+class DashboardViewsTests(TestCase):
     """Regression tests for analytics dashboard views."""
+
+    client_class = APIClient
 
     def setUp(self):
         self.user = User.objects.create_user(

--- a/backend/apps/integrations/services/google_drive.py
+++ b/backend/apps/integrations/services/google_drive.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from typing import Dict, List, Optional, Callable, Any
 
 from django.conf import settings
+from django.core.exceptions import ObjectDoesNotExist
 from django.utils import timezone
 from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials
@@ -145,9 +146,9 @@ class GoogleDriveService:
 def get_drive_service_for_user(user) -> GoogleDriveService:
     """Get Google Drive service instance for a user."""
     try:
-        profile = user.userprofile
-    except:
-        raise ValueError("User profile not found")
+        profile = user.profile
+    except ObjectDoesNotExist as exc:
+        raise ValueError("User profile not found") from exc
     
     if not profile.google_drive_connected:
         raise ValueError("User has not connected Google Drive")

--- a/backend/tests/test_dashboard_views.py
+++ b/backend/tests/test_dashboard_views.py
@@ -1,0 +1,3 @@
+"""Compatibility shim to expose analytics dashboard regression tests."""
+
+from apps.analytics.tests.dashboard_views_regression import *  # noqa: F401,F403


### PR DESCRIPTION
## Summary
- bootstrap Django when importing analytics regression tests and expose them through the shared test package
- convert the analytics dashboard regression tests to a Django `TestCase` and add a compatibility shim for pytest discovery
- fix the Google Drive service helper to use the correct user profile relation and raise a clearer error when missing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68dce8e3ab488328baf03bbd49ee6614