### PR TITLE
Improve dashboard mobile responsiveness

### DIFF
--- a/frontend/app/dashboard/analytics/page.tsx
+++ b/frontend/app/dashboard/analytics/page.tsx
@@ -85,8 +85,8 @@ export default function AnalyticsPage() {
     <div className="min-h-screen bg-gradient-to-br from-gray-900 via-purple-900 to-blue-900">
       {/* Header */}
       <div className="bg-black/20 border-b border-white/10">
-        <div className="max-w-7xl mx-auto px-6 py-4">
-          <div className="flex items-center justify-between">
+        <div className="mx-auto max-w-7xl px-4 py-4 sm:px-6">
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
             <div className="flex items-center gap-4">
               <button
                 onClick={() => router.push("/dashboard")}
@@ -99,9 +99,9 @@ export default function AnalyticsPage() {
                 <p className="text-white/60 text-sm">Insights into platform performance and user engagement</p>
               </div>
             </div>
-            
-            <div className="flex items-center gap-3">
-              <span className="px-3 py-1 bg-blue-600/20 text-blue-400 rounded-full text-sm font-medium">
+
+            <div className="flex items-center gap-3 md:self-end">
+              <span className="rounded-full bg-blue-600/20 px-3 py-1 text-sm font-medium text-blue-400">
                 📊 Live Data
               </span>
             </div>
@@ -111,8 +111,8 @@ export default function AnalyticsPage() {
 
       {/* Navigation Tabs */}
       <div className="bg-black/10 border-b border-white/10">
-        <div className="max-w-7xl mx-auto px-6">
-          <div className="flex space-x-8">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6">
+          <div className="-mx-4 flex gap-4 overflow-x-auto px-4 sm:mx-0 sm:px-0">
             {[
               { id: "overview", label: "Overview", icon: "📊" },
               { id: "personal", label: "Personal", icon: "👤" },
@@ -122,7 +122,7 @@ export default function AnalyticsPage() {
               <button
                 key={tab.id}
                 onClick={() => setActiveTab(tab.id as any)}
-                className={`flex items-center gap-2 px-4 py-4 text-sm font-medium border-b-2 transition-colors ${
+                className={`flex flex-shrink-0 items-center gap-2 whitespace-nowrap border-b-2 px-3 py-3 text-sm font-medium transition-colors sm:px-4 sm:py-4 ${
                   activeTab === tab.id
                     ? "text-blue-400 border-blue-400"
                     : "text-white/60 border-transparent hover:text-white"
@@ -137,7 +137,7 @@ export default function AnalyticsPage() {
       </div>
 
       {/* Content */}
-      <div className="max-w-7xl mx-auto px-6 py-8">
+      <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6">
         {/* Overview Tab */}
         {activeTab === "overview" && (
           <div className="space-y-8">

--- a/frontend/components/dashboard/dashboard-layout.tsx
+++ b/frontend/components/dashboard/dashboard-layout.tsx
@@ -131,7 +131,7 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900">
+    <div className="min-h-screen overflow-x-hidden bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900">
       {/* Dashboard Header - hide duplicate header on mobile */}
       <div className="hidden md:block">
         <DashboardHeader />
@@ -147,7 +147,7 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
       {/* Mobile Navigation - Shown only on mobile */}
       <MobileNavigation currentUser={user} />
 
-      <div className="relative z-10 flex min-h-screen pt-14 md:pt-16">
+      <div className="relative z-10 flex min-h-screen w-full flex-col pt-14 md:flex-row md:pt-16">
         {/* Enhanced Sidebar - Hidden on mobile, shown on desktop */}
         <aside className={cn(
           "hidden md:fixed left-0 top-0 h-full bg-black/20 backdrop-blur-xl border-r border-white/10 transition-all duration-300 z-50 md:block",
@@ -324,13 +324,13 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
         {/* Main Content */}
         <main
           className={cn(
-            "flex-1 transition-all duration-300 mb-20 md:mb-0",
-            "md:" + (isCollapsed ? "ml-20" : "ml-80")
+            "flex-1 w-full overflow-x-hidden transition-all duration-300 pb-24 md:pb-0",
+            isCollapsed ? "md:ml-20" : "md:ml-80"
           )}
         >
           {/* Page Content */}
-          <div className="flex-1 p-6">
-            <div className="max-w-7xl mx-auto">
+          <div className="flex-1 px-4 py-6 sm:px-6 lg:px-8">
+            <div className="mx-auto w-full max-w-7xl">
               {children}
             </div>
           </div>


### PR DESCRIPTION
## Summary
- prevent horizontal overflow in the shared dashboard layout and ensure content padding scales on smaller screens
- update the analytics dashboard header and tab navigation to wrap and scroll cleanly on mobile viewports

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_68de64001b84832882098635ac7de907