### PR TITLE
Implement mobile push service topic APIs and tests

### DIFF
--- a/backend/apps/notifications/tests/test_mobile_push_service.py
+++ b/backend/apps/notifications/tests/test_mobile_push_service.py
@@ -1,0 +1,124 @@
+"""Unit tests for the mobile push service integration."""
+
+import os
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.notifications_testing")
+
+import django
+
+django.setup()
+
+from django.test import TestCase
+
+from apps.notifications.models import NotificationPreferences
+from shared.services.mobile_push_service import MobilePushService
+from tests.factories import UserFactory
+
+
+class DummyProvider:
+    """Provider used to capture interactions during tests."""
+
+    def __init__(self, failure_count: int = 0, status: str = "sent", message_id: str = "msg-1"):
+        self.subscribed = []
+        self.unsubscribed = []
+        self.sent_tokens = []
+        self.sent_topics = []
+        self.failure_count = failure_count
+        self.status = status
+        self.message_id = message_id
+
+    def subscribe_to_topic(self, tokens, topic, metadata=None):
+        self.subscribed.append((tuple(tokens), topic, metadata or {}))
+        return {"success_count": len(tokens), "failure_count": self.failure_count}
+
+    def unsubscribe_from_topic(self, tokens, topic, metadata=None):
+        self.unsubscribed.append((tuple(tokens), topic, metadata or {}))
+        return {"success_count": len(tokens), "failure_count": self.failure_count}
+
+    def send_to_tokens(self, tokens, payload):
+        self.sent_tokens.append((tuple(tokens), payload))
+        return {"failure_count": self.failure_count, "message_ids": {t: f"id-{t}" for t in tokens}}
+
+    def send_to_topic(self, topic, payload):
+        self.sent_topics.append((topic, payload))
+        return {"message_id": self.message_id, "status": self.status}
+
+
+class MobilePushServiceTests(TestCase):
+    """Test suite covering push service helpers."""
+
+    def test_subscribe_to_topic_succeeds(self):
+        provider = DummyProvider()
+        service = MobilePushService(provider=provider)
+
+        response = service.subscribe_to_topic(["token-a", "token-b"], "general")
+
+        self.assertEqual(response["success_count"], 2)
+        self.assertEqual(provider.subscribed, [(("token-a", "token-b"), "general", {})])
+
+    def test_subscribe_to_topic_failure_raises(self):
+        provider = DummyProvider(failure_count=1)
+        service = MobilePushService(provider=provider)
+
+        with self.assertRaises(RuntimeError):
+            service.subscribe_to_topic(["token-a"], "general")
+
+    def test_send_to_user_requires_registered_token(self):
+        user = UserFactory()
+        service = MobilePushService(provider=DummyProvider())
+
+        with self.assertRaises(RuntimeError):
+            service.send_to_user(user=user, title="Hello", body="World")
+
+    def test_send_to_user_delivers_payload(self):
+        user = UserFactory()
+        NotificationPreferences.objects.create(
+            user=user,
+            push_enabled=True,
+            push_token="abc123",
+        )
+
+        provider = DummyProvider()
+        service = MobilePushService(provider=provider)
+
+        response = service.send_to_user(
+            user=user,
+            title="Greetings",
+            body="Hello there",
+            data={"foo": "bar"},
+            metadata={"source": "unit"},
+        )
+
+        self.assertTrue(provider.sent_tokens)
+        tokens, payload = provider.sent_tokens[0]
+        self.assertEqual(tokens, ("abc123",))
+        self.assertEqual(payload["title"], "Greetings")
+        self.assertEqual(payload["data"], {"foo": "bar"})
+        self.assertEqual(payload["metadata"], {"source": "unit"})
+        self.assertTrue(response["message_ids"]["abc123"].startswith("id-"))
+
+    def test_send_to_topic_returns_message_id(self):
+        provider = DummyProvider(message_id="topic-123")
+        service = MobilePushService(provider=provider)
+
+        message_id = service.send_to_topic(
+            topic="general",
+            title="Title",
+            body="Body",
+            data={"extra": True},
+            metadata={"segment": "all"},
+        )
+
+        self.assertEqual(message_id, "topic-123")
+        self.assertTrue(provider.sent_topics)
+        topic, payload = provider.sent_topics[0]
+        self.assertEqual(topic, "general")
+        self.assertEqual(payload["data"], {"extra": True})
+        self.assertEqual(payload["metadata"], {"segment": "all"})
+
+    def test_send_to_topic_reports_provider_error(self):
+        provider = DummyProvider(status="failed")
+        service = MobilePushService(provider=provider)
+
+        with self.assertRaises(RuntimeError):
+            service.send_to_topic(topic="general", title="t", body="b")

--- a/backend/apps/notifications/tests/test_push_notification_views.py
+++ b/backend/apps/notifications/tests/test_push_notification_views.py
@@ -1,0 +1,103 @@
+"""API tests for push notification endpoints."""
+
+import os
+from unittest.mock import patch
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.notifications_testing")
+
+import django
+
+django.setup()
+
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.notifications.models import NotificationPreferences
+from shared.services.mobile_push_service import mobile_push_service
+from tests.factories import UserFactory
+
+
+class PushNotificationViewTests(APITestCase):
+    """Exercises the push-notification endpoints."""
+
+    def test_update_push_token_subscribes(self):
+        user = UserFactory()
+        self.client.force_authenticate(user=user)
+
+        with patch.object(mobile_push_service, "subscribe_to_topic", autospec=True) as subscribe_mock:
+            response = self.client.post(
+                reverse("notifications:update-push-token"),
+                {"push_token": "abc123", "device_type": "ios"},
+                format="json",
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        subscribe_mock.assert_called_once_with(["abc123"], "general_announcements")
+
+    def test_remove_push_token_unsubscribes(self):
+        user = UserFactory()
+        NotificationPreferences.objects.create(
+            user=user,
+            push_token="xyz789",
+            push_enabled=True,
+        )
+
+        self.client.force_authenticate(user=user)
+
+        with patch.object(mobile_push_service, "unsubscribe_from_topic", autospec=True) as unsubscribe_mock:
+            response = self.client.post(reverse("notifications:remove-push-token"), format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        unsubscribe_mock.assert_called_once_with(["xyz789"], "general_announcements")
+        prefs = NotificationPreferences.objects.get(user=user)
+        self.assertEqual(prefs.push_token, "")
+        self.assertFalse(prefs.push_enabled)
+
+    def test_send_test_push_uses_service(self):
+        user = UserFactory()
+        NotificationPreferences.objects.create(
+            user=user,
+            push_token="abc",
+            push_enabled=True,
+        )
+
+        self.client.force_authenticate(user=user)
+
+        with patch.object(
+            mobile_push_service,
+            "send_to_user",
+            return_value={"message_ids": {"abc": "id-abc"}},
+        ) as send_mock:
+            response = self.client.post(reverse("notifications:test-push"), format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        send_mock.assert_called_once()
+        self.assertEqual(response.data["result"], {"message_ids": {"abc": "id-abc"}})
+
+    def test_broadcast_push_requires_admin_and_calls_service(self):
+        admin = UserFactory()
+        admin.is_staff = True
+        admin.save()
+        self.client.force_authenticate(user=admin)
+
+        with patch.object(
+            mobile_push_service,
+            "send_to_topic",
+            return_value="msg-123",
+        ) as send_topic_mock:
+            response = self.client.post(
+                reverse("notifications:broadcast-push"),
+                {"title": "Hello", "body": "World", "topic": "news"},
+                format="json",
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        send_topic_mock.assert_called_once()
+        kwargs = send_topic_mock.call_args.kwargs
+        self.assertEqual(kwargs["topic"], "news")
+        self.assertEqual(kwargs["title"], "Hello")
+        self.assertEqual(kwargs["body"], "World")
+        self.assertEqual(kwargs["data"]["type"], "broadcast")
+        self.assertIn("timestamp", kwargs["data"])
+        self.assertEqual(response.data["message_id"], "msg-123")

--- a/backend/config/notifications_test_urls.py
+++ b/backend/config/notifications_test_urls.py
@@ -1,0 +1,12 @@
+"""URL configuration for notifications tests."""
+
+from django.urls import include, path
+
+from .simple_urls import urlpatterns as base_urlpatterns
+
+urlpatterns = list(base_urlpatterns) + [
+    path(
+        'api/notifications/',
+        include(('apps.notifications.urls', 'notifications'), namespace='notifications'),
+    ),
+]

--- a/backend/config/settings/notifications_testing.py
+++ b/backend/config/settings/notifications_testing.py
@@ -1,0 +1,7 @@
+"""Testing settings that include the notifications app."""
+
+from .testing import *  # noqa
+
+INSTALLED_APPS = list(INSTALLED_APPS) + ['apps.notifications']
+
+ROOT_URLCONF = 'config.notifications_test_urls'

--- a/backend/shared/services/mobile_push_service.py
+++ b/backend/shared/services/mobile_push_service.py
@@ -1,40 +1,265 @@
 """Mobile push notification service."""
 
 import logging
-from typing import Dict, Any, List, Optional
+import uuid
+from typing import Any, Dict, Iterable, List, Optional
 
 logger = logging.getLogger(__name__)
 
 
+class _MockPushProvider:
+    """Simple mock provider used as a default implementation."""
+
+    def subscribe_to_topic(
+        self, tokens: List[str], topic: str, metadata: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        return {
+            "topic": topic,
+            "success_count": len(tokens),
+            "failure_count": 0,
+            "metadata": metadata or {},
+        }
+
+    def unsubscribe_from_topic(
+        self, tokens: List[str], topic: str, metadata: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        return {
+            "topic": topic,
+            "success_count": len(tokens),
+            "failure_count": 0,
+            "metadata": metadata or {},
+        }
+
+    def send_to_tokens(self, tokens: List[str], payload: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "message_ids": {token: str(uuid.uuid4()) for token in tokens},
+            "failure_count": 0,
+            "payload": payload,
+        }
+
+    def send_to_topic(self, topic: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "message_id": str(uuid.uuid4()),
+            "topic": topic,
+            "status": "sent",
+            "payload": payload,
+        }
+
+
 class MobilePushService:
     """Service for mobile push notifications."""
-    
-    def send_push_notification(self, device_token: str, title: str, 
-                              body: str, data: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+
+    def __init__(self, provider: Optional[Any] = None) -> None:
+        self.provider = provider or _MockPushProvider()
+
+    def _normalize_tokens(self, device_tokens: Iterable[str]) -> List[str]:
+        if isinstance(device_tokens, str):
+            tokens = [device_tokens]
+        elif isinstance(device_tokens, Iterable):
+            tokens = [token for token in device_tokens]
+        else:
+            raise TypeError("device_tokens must be a string or iterable of strings")
+
+        cleaned_tokens = [token.strip() for token in tokens if isinstance(token, str) and token.strip()]
+        if not cleaned_tokens:
+            raise ValueError("At least one valid device token must be provided")
+        return cleaned_tokens
+
+    def _send_to_tokens(self, tokens: List[str], payload: Dict[str, Any]) -> Dict[str, Any]:
+        try:
+            response = self.provider.send_to_tokens(tokens, payload)
+        except Exception as exc:  # pragma: no cover - defensive guard
+            raise RuntimeError(f"Failed to send push notification: {exc}") from exc
+
+        failures = response.get("failure_count", 0)
+        if failures:
+            raise RuntimeError(
+                f"Push provider reported {failures} failures while sending notification"
+            )
+        return response
+
+    def subscribe_to_topic(
+        self,
+        device_tokens: Iterable[str],
+        topic: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Subscribe one or more device tokens to a topic."""
+
+        tokens = self._normalize_tokens(device_tokens)
+        if not topic or not topic.strip():
+            raise ValueError("Topic must be a non-empty string")
+
+        try:
+            response = self.provider.subscribe_to_topic(tokens, topic.strip(), metadata or {})
+        except Exception as exc:  # pragma: no cover - defensive guard
+            raise RuntimeError(
+                f"Failed to subscribe tokens to topic '{topic}': {exc}"
+            ) from exc
+
+        if response.get("failure_count", 0):
+            raise RuntimeError(
+                f"Push provider reported {response['failure_count']} failures when subscribing to '{topic}'"
+            )
+
+        logger.info("Subscribed %s tokens to topic '%s'", len(tokens), topic)
+        return response
+
+    def unsubscribe_from_topic(
+        self,
+        device_tokens: Iterable[str],
+        topic: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Unsubscribe one or more device tokens from a topic."""
+
+        tokens = self._normalize_tokens(device_tokens)
+        if not topic or not topic.strip():
+            raise ValueError("Topic must be a non-empty string")
+
+        try:
+            response = self.provider.unsubscribe_from_topic(tokens, topic.strip(), metadata or {})
+        except Exception as exc:  # pragma: no cover - defensive guard
+            raise RuntimeError(
+                f"Failed to unsubscribe tokens from topic '{topic}': {exc}"
+            ) from exc
+
+        if response.get("failure_count", 0):
+            raise RuntimeError(
+                f"Push provider reported {response['failure_count']} failures when unsubscribing from '{topic}'"
+            )
+
+        logger.info("Unsubscribed %s tokens from topic '%s'", len(tokens), topic)
+        return response
+
+    def send_to_user(
+        self,
+        user: Any,
+        title: str,
+        body: str,
+        data: Optional[Dict[str, Any]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Send a push notification directly to a user's registered devices."""
+
+        if not user:
+            raise ValueError("user is required")
+        if not title or not title.strip():
+            raise ValueError("title is required")
+        if not body or not body.strip():
+            raise ValueError("body is required")
+
+        from apps.notifications.models import NotificationPreferences
+
+        preferences = NotificationPreferences.objects.filter(
+            user=user, push_token__isnull=False
+        ).exclude(push_token="").first()
+
+        if not preferences or not preferences.push_enabled:
+            raise RuntimeError("User does not have push notifications enabled or registered")
+
+        tokens = self._normalize_tokens([preferences.push_token])
+        payload: Dict[str, Any] = {
+            "title": title.strip(),
+            "body": body.strip(),
+        }
+        if data:
+            payload["data"] = data
+        if metadata:
+            payload["metadata"] = metadata
+
+        return self._send_to_tokens(tokens, payload)
+
+    def send_to_topic(
+        self,
+        topic: str,
+        title: str,
+        body: str,
+        data: Optional[Dict[str, Any]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        """Send a push notification to all subscribers of a topic."""
+
+        if not topic or not topic.strip():
+            raise ValueError("Topic must be a non-empty string")
+        if not title or not title.strip():
+            raise ValueError("title is required")
+        if not body or not body.strip():
+            raise ValueError("body is required")
+
+        payload: Dict[str, Any] = {
+            "title": title.strip(),
+            "body": body.strip(),
+        }
+        if data:
+            payload["data"] = data
+        if metadata:
+            payload["metadata"] = metadata
+
+        try:
+            response = self.provider.send_to_topic(topic.strip(), payload)
+        except Exception as exc:  # pragma: no cover - defensive guard
+            raise RuntimeError(f"Failed to send notification to topic '{topic}': {exc}") from exc
+
+        if response.get("status") not in {None, "sent", "success"}:
+            raise RuntimeError(
+                f"Push provider returned unexpected status '{response.get('status')}' for topic '{topic}'"
+            )
+
+        message_id = response.get("message_id")
+        if not message_id:
+            raise RuntimeError(
+                f"Push provider did not return a message id for topic '{topic}'"
+            )
+
+        logger.info("Sent topic notification '%s' with id %s", topic, message_id)
+        return message_id
+
+    def send_push_notification(
+        self,
+        device_token: str,
+        title: str,
+        body: str,
+        data: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
         """Send push notification to a device."""
-        logger.info(f"Sending push notification to device: {title}")
-        return {"message_id": "placeholder", "status": "sent"}
-    
-    def send_bulk_push(self, device_tokens: List[str], title: str, 
-                      body: str, data: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        logger.info("Sending push notification to device: %s", title)
+        payload = {"title": title, "body": body}
+        if data:
+            payload["data"] = data
+        return self._send_to_tokens(self._normalize_tokens([device_token]), payload)
+
+    def send_bulk_push(
+        self,
+        device_tokens: List[str],
+        title: str,
+        body: str,
+        data: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
         """Send push notification to multiple devices."""
-        logger.info(f"Sending bulk push notification to {len(device_tokens)} devices")
-        return {"batch_id": "placeholder", "status": "sent"}
-    
-    def register_device(self, user_id: str, device_token: str, 
-                       platform: str = "android") -> Dict[str, Any]:
+        logger.info(
+            "Sending bulk push notification to %s devices", len(device_tokens)
+        )
+        payload = {"title": title, "body": body}
+        if data:
+            payload["data"] = data
+        return self._send_to_tokens(self._normalize_tokens(device_tokens), payload)
+
+    def register_device(
+        self, user_id: str, device_token: str, platform: str = "android"
+    ) -> Dict[str, Any]:
         """Register a device for push notifications."""
-        logger.info(f"Registering {platform} device for user {user_id}")
+        logger.info("Registering %s device for user %s", platform, user_id)
         return {"device_id": "placeholder", "status": "registered"}
-    
+
     def unregister_device(self, device_token: str) -> bool:
         """Unregister a device."""
-        logger.info(f"Unregistering device {device_token}")
+        logger.info("Unregistering device %s", device_token)
         return True
-    
+
     def get_user_devices(self, user_id: str) -> List[Dict[str, Any]]:
         """Get registered devices for a user."""
-        logger.info(f"Getting devices for user {user_id}")
+        logger.info("Getting devices for user %s", user_id)
         return []
 
 


### PR DESCRIPTION
## Summary
- implement topic subscription and delivery helpers in the mobile push service with validation and provider integration
- add dedicated Django test settings and URL configuration to exercise notification endpoints
- cover the new service methods and notification API endpoints with unit tests

## Testing
- `python manage.py test apps.notifications.tests --settings=config.settings.notifications_testing`


------
https://chatgpt.com/codex/tasks/task_b_68de7ed93f2c83288a44be2de8ff322a