### PR TITLE
Add warning notification helper and moderation tests

### DIFF
--- a/backend/apps/moderation/tests/__init__.py
+++ b/backend/apps/moderation/tests/__init__.py
@@ -1,0 +1,2 @@
+"""Test suite for the moderation app."""
+

--- a/backend/apps/moderation/tests/test_moderation_notifications.py
+++ b/backend/apps/moderation/tests/test_moderation_notifications.py
@@ -1,0 +1,67 @@
+"""Tests for moderation warning actions and notifications."""
+
+import os
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import patch
+
+import django
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.testing")
+django.setup()
+
+from apps.moderation.views import _apply_moderation_action
+from shared.services.notification_service import notification_service
+
+
+class ModerationWarningActionTests(TestCase):
+    """Ensure moderation warning actions trigger the appropriate notifications."""
+
+    def setUp(self):
+        self.reported_user = SimpleNamespace(id="user-123")
+        self.report = SimpleNamespace(reported_user=self.reported_user)
+
+    def test_warning_action_triggers_warning_notification(self):
+        action_data = {
+            "action_type": "warning",
+            "description": "Please adhere to the community guidelines.",
+        }
+
+        with patch(
+            "shared.services.notification_service.notification_service.send_warning_notification"
+        ) as mock_warning:
+            _apply_moderation_action(self.report, action_data)
+
+        mock_warning.assert_called_once_with(
+            user=self.reported_user,
+            reason=action_data["description"],
+        )
+
+    def test_send_warning_notification_formats_message(self):
+        reason = "Spamming promotional links"
+        action_required = "Please review the community guidelines."
+        support_url = "https://example.com/guidelines"
+
+        with patch.object(notification_service, "send_notification") as mock_send:
+            notification_service.send_warning_notification(
+                user=self.reported_user,
+                reason=reason,
+                action_required=action_required,
+                support_url=support_url,
+            )
+
+        expected_message = "\n".join(
+            [
+                "Our moderation team has issued a warning regarding your recent activity.",
+                f"Reason: {reason}",
+                f"Next steps: {action_required}",
+                f"For more information visit: {support_url}",
+            ]
+        )
+
+        mock_send.assert_called_once_with(
+            user_id=str(self.reported_user.id),
+            title="Community Guidelines Warning",
+            message=expected_message,
+            notification_type="warning",
+        )

--- a/backend/config/settings/testing.py
+++ b/backend/config/settings/testing.py
@@ -144,6 +144,7 @@ INSTALLED_APPS = [
     'apps.authentication',
     'apps.integrations',
     'apps.analytics',
+    'apps.moderation',
     'apps.parties',
     'apps.videos',
 ]

--- a/backend/shared/services/notification_service.py
+++ b/backend/shared/services/notification_service.py
@@ -8,12 +8,51 @@ logger = logging.getLogger(__name__)
 
 class NotificationService:
     """Service for handling notifications."""
-    
-    def send_notification(self, user_id: str, title: str, message: str, 
+
+    def send_notification(self, user_id: str, title: str, message: str,
                          notification_type: str = "info") -> Dict[str, Any]:
         """Send a notification to a user."""
         logger.info(f"Sending {notification_type} notification to user {user_id}: {title}")
         return {"notification_id": "placeholder", "status": "sent"}
+
+    def send_warning_notification(self, user, reason: str, **kwargs) -> Dict[str, Any]:
+        """Send a warning notification to a user."""
+        user_id = getattr(user, "id", user)
+        if user_id is None:
+            raise ValueError("A valid user or user identifier is required to send a warning notification")
+
+        title = kwargs.pop('title', "Community Guidelines Warning")
+        custom_message = kwargs.pop('message', None)
+        action_required = kwargs.pop('action_required', None)
+        support_url = kwargs.pop('support_url', None)
+
+        if custom_message:
+            message = custom_message
+        else:
+            message_lines = [
+                "Our moderation team has issued a warning regarding your recent activity.",
+                f"Reason: {reason}",
+            ]
+            if action_required:
+                message_lines.append(f"Next steps: {action_required}")
+            if support_url:
+                message_lines.append(f"For more information visit: {support_url}")
+            message = "\n".join(message_lines)
+
+        if kwargs:
+            logger.debug(
+                "Unused warning notification options provided for user %s: %s",
+                user_id,
+                kwargs,
+            )
+
+        logger.info("Sending warning notification to user %s", user_id)
+        return self.send_notification(
+            user_id=str(user_id),
+            title=title,
+            message=message,
+            notification_type="warning",
+        )
     
     def send_bulk_notification(self, user_ids: List[str], title: str, 
                               message: str, notification_type: str = "info") -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- add a `send_warning_notification` helper that formats a moderation warning and delegates to the base notifier
- include the moderation app in the testing settings so its utilities can be imported in tests
- create tests that cover the moderation warning action path and ensure the notification helper formats and dispatches warnings

## Testing
- pytest backend/apps/moderation/tests/test_moderation_notifications.py

------
https://chatgpt.com/codex/tasks/task_b_68de7edacac88328b949b365561c5391