### PR TITLE
Enhance Google Drive integration for uploads and streaming

### DIFF
--- a/backend/apps/integrations/services/google_drive.py
+++ b/backend/apps/integrations/services/google_drive.py
@@ -1,5 +1,7 @@
 """Google Drive integration service."""
 import logging
+import mimetypes
+import os
 from datetime import timedelta
 from typing import Dict, List, Optional, Callable, Any
 
@@ -9,6 +11,7 @@ from django.utils import timezone
 from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
+from googleapiclient.http import MediaFileUpload
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +30,16 @@ class GoogleDriveService:
     ):
         """Initialize Google Drive service."""
         self.on_credentials_updated = on_credentials_updated
-        
+
+        scopes = getattr(
+            settings,
+            'GOOGLE_DRIVE_SCOPES',
+            [
+                'https://www.googleapis.com/auth/drive.readonly',
+                'https://www.googleapis.com/auth/drive.file',
+            ],
+        )
+
         if drive_service:
             self.drive_service = drive_service
             self.credentials = credentials
@@ -39,7 +51,7 @@ class GoogleDriveService:
                 token_uri='https://oauth2.googleapis.com/token',
                 client_id=getattr(settings, 'GOOGLE_DRIVE_CLIENT_ID', ''),
                 client_secret=getattr(settings, 'GOOGLE_DRIVE_CLIENT_SECRET', ''),
-                scopes=['https://www.googleapis.com/auth/drive.readonly']
+                scopes=scopes
             )
             
             if token_expiry:
@@ -120,27 +132,112 @@ class GoogleDriveService:
     
     def get_file_info(self, file_id: str) -> Dict[str, Any]:
         """Get file information."""
+        self._refresh_credentials_if_needed()
         file_info = self.drive_service.files().get(
             fileId=file_id,
-            fields="id,name,mimeType,size,thumbnailLink,videoMediaMetadata"
+            fields=(
+                "id,name,mimeType,size,thumbnailLink,videoMediaMetadata,"
+                "webContentLink,webViewLink"
+            )
         ).execute()
-        
+
         return {
             'id': file_info['id'],
             'name': file_info['name'],
             'mime_type': file_info['mimeType'],
             'size': int(file_info.get('size', 0)),
             'thumbnail_url': file_info.get('thumbnailLink', ''),
+            'download_url': file_info.get('webContentLink') or self.get_download_url(file_id),
+            'web_view_link': file_info.get('webViewLink', ''),
+            'video_metadata': file_info.get('videoMediaMetadata', {}),
         }
-    
+
     def get_download_url(self, file_id: str) -> str:
         """Get download URL for a file."""
         return f"https://drive.google.com/uc?export=download&id={file_id}"
-    
-    def get_streaming_url(self, file_id: str, force_refresh: bool = False) -> str:
-        """Get streaming URL for a video file."""
-        # For now, use the download URL as streaming URL
-        return self.get_download_url(file_id)
+
+    def upload_file(
+        self,
+        file_path: str,
+        name: Optional[str] = None,
+        folder_id: Optional[str] = None,
+        mime_type: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Upload a file to Google Drive."""
+        self._refresh_credentials_if_needed()
+
+        resolved_name = name or os.path.basename(file_path)
+        resolved_mime = mime_type or mimetypes.guess_type(resolved_name)[0] or 'application/octet-stream'
+
+        metadata: Dict[str, Any] = {'name': resolved_name}
+        if folder_id:
+            metadata['parents'] = [folder_id]
+
+        media = MediaFileUpload(file_path, mimetype=resolved_mime, resumable=True)
+
+        try:
+            request = self.drive_service.files().create(
+                body=metadata,
+                media_body=media,
+                fields="id,name,mimeType,size,webContentLink",
+            )
+            result = request.execute()
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.error("Failed to upload file to Google Drive: %s", exc)
+            raise
+
+        file_id = result.get('id')
+
+        return {
+            'id': file_id,
+            'name': result.get('name', resolved_name),
+            'mime_type': result.get('mimeType', resolved_mime),
+            'size': int(result.get('size', 0)),
+            'download_url': result.get('webContentLink') or (
+                self.get_download_url(file_id) if file_id else ''
+            ),
+        }
+
+    def delete_file(self, file_id: str) -> bool:
+        """Delete a file from Google Drive."""
+        self._refresh_credentials_if_needed()
+        try:
+            self.drive_service.files().delete(fileId=file_id).execute()
+            return True
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.error("Failed to delete file %s from Google Drive: %s", file_id, exc)
+            return False
+
+    def generate_streaming_url(self, file_id: str, force_refresh: bool = False) -> str:
+        """Generate a streaming URL for a file."""
+        if force_refresh and self.credentials and self.credentials.refresh_token:
+            try:
+                self.credentials.refresh(Request())
+                if self.on_credentials_updated:
+                    self.on_credentials_updated(self.credentials)
+            except Exception as exc:  # pragma: no cover - defensive logging
+                logger.error("Forced refresh of Google Drive credentials failed: %s", exc)
+                raise
+
+        self._refresh_credentials_if_needed()
+
+        try:
+            file_info = self.drive_service.files().get(
+                fileId=file_id,
+                fields="id,webContentLink",
+            ).execute()
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.error("Failed to generate streaming URL for %s: %s", file_id, exc)
+            raise
+
+        streaming_url = file_info.get('webContentLink')
+        if not streaming_url:
+            streaming_url = self.get_download_url(file_id)
+
+        if not streaming_url:
+            raise ValueError("Streaming URL not available")
+
+        return streaming_url
 
 
 def get_drive_service_for_user(user) -> GoogleDriveService:


### PR DESCRIPTION
## Summary
- add write-enabled Google Drive scopes and implement upload, delete, and streaming helpers that refresh credentials as needed
- expand Google Drive file metadata responses with download URLs and video details consumed by video views
- cover success and failure cases for the new helpers with updated integration service tests

## Testing
- pytest backend/apps/integrations/tests/test_google_drive_service.py

------
https://chatgpt.com/codex/tasks/task_b_68de87a8aecc83288be2968c661802ea