### PR TITLE
Ensure Google Drive file info exposes download metadata

### DIFF
--- a/backend/apps/integrations/services/google_drive.py
+++ b/backend/apps/integrations/services/google_drive.py
@@ -141,15 +141,21 @@ class GoogleDriveService:
             )
         ).execute()
 
+        download_url = file_info.get('webContentLink')
+        if not download_url:
+            download_url = self.get_download_url(file_info.get('id', file_id))
+
+        video_metadata = file_info.get('videoMediaMetadata') or {}
+
         return {
             'id': file_info['id'],
             'name': file_info['name'],
             'mime_type': file_info['mimeType'],
             'size': int(file_info.get('size', 0)),
             'thumbnail_url': file_info.get('thumbnailLink', ''),
-            'download_url': file_info.get('webContentLink') or self.get_download_url(file_id),
+            'download_url': download_url,
             'web_view_link': file_info.get('webViewLink', ''),
-            'video_metadata': file_info.get('videoMediaMetadata', {}),
+            'video_metadata': video_metadata,
         }
 
     def get_download_url(self, file_id: str) -> str:

--- a/backend/apps/integrations/tests/test_google_drive_service.py
+++ b/backend/apps/integrations/tests/test_google_drive_service.py
@@ -290,6 +290,32 @@ class GoogleDriveServiceUnitTests(TestCase):
         self.assertEqual(info['download_url'], 'content')
         self.assertEqual(info['video_metadata']['width'], 1280)
 
+    def test_get_file_info_falls_back_to_generated_download_url(self):
+        files_api = MagicMock()
+        files_api.get.return_value.execute.return_value = {
+            'id': 'file-654',
+            'name': 'Fallback.mp4',
+            'mimeType': 'video/mp4',
+            'size': '2048',
+            'thumbnailLink': 'thumb',
+            'webContentLink': None,
+            'webViewLink': 'view',
+        }
+
+        drive_service = MagicMock()
+        drive_service.files.return_value = files_api
+
+        service = GoogleDriveService(drive_service=drive_service, credentials=MagicMock())
+
+        with patch.object(service, '_refresh_credentials_if_needed') as refresh_mock, \
+                patch.object(service, 'get_download_url', return_value='generated-url') as url_mock:
+            info = service.get_file_info('file-654')
+
+        refresh_mock.assert_called_once()
+        url_mock.assert_called_once_with('file-654')
+        self.assertEqual(info['download_url'], 'generated-url')
+        self.assertEqual(info['video_metadata'], {})
+
     def test_generate_streaming_url_error_raises(self):
         files_api = MagicMock()
         files_api.get.return_value.execute.side_effect = RuntimeError('fail')


### PR DESCRIPTION
## Summary
- ensure Google Drive file details always include a download URL and raw video metadata
- extend service unit tests to cover the richer Google Drive metadata payload

## Testing
- pytest backend/apps/integrations/tests/test_google_drive_service.py

------
https://chatgpt.com/codex/tasks/task_b_68de89a2315c83289aa4d75b58372087