### PR TITLE
Normalize real-time analytics data

### DIFF
--- a/frontend/Watch_Party_API.yaml
+++ b/frontend/Watch_Party_API.yaml
@@ -23,7 +23,11 @@ paths:
       - {}
       responses:
         '200':
-          description: No response body
+          description: Real-time analytics metrics
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RealTimeAnalyticsResponse'
       x-authentication:
         types:
         - JWTAuthentication
@@ -10178,6 +10182,118 @@ components:
         data:
           type: object
           additionalProperties: {}
+    RealTimeAnalyticsActivity:
+      type: object
+      description: Aggregated count of events observed in the last hour
+      properties:
+        event_type:
+          type: string
+          description: Event category (e.g., user_login, party_join)
+        count:
+          type: integer
+          description: Number of events recorded in the window
+          minimum: 0
+      required:
+      - count
+      - event_type
+    RealTimeAnalyticsEngagement:
+      type: object
+      description: Live engagement metrics sampled from active watch parties
+      properties:
+        concurrent_viewers:
+          type: integer
+          description: Number of active viewers in the last 5 minutes
+          minimum: 0
+        messages_per_minute:
+          type: integer
+          description: Chat messages sent per minute across live parties
+          minimum: 0
+        reactions_per_minute:
+          type: integer
+          description: Reactions submitted per minute across live parties
+          minimum: 0
+      required:
+      - concurrent_viewers
+      - messages_per_minute
+      - reactions_per_minute
+    RealTimeAnalyticsSystemHealth:
+      type: object
+      description: Snapshot of system resource consumption
+      properties:
+        system_load:
+          type: number
+          format: float
+          description: Overall platform load (mirrors CPU usage)
+        cpu_usage:
+          type: number
+          format: float
+          description: Current CPU usage percentage
+        memory_usage:
+          type: number
+          format: float
+          description: Current memory usage percentage
+        disk_usage:
+          type: number
+          format: float
+          description: Current disk usage percentage
+        network_traffic:
+          type: number
+          format: float
+          description: Network throughput in MB/s
+      required:
+      - cpu_usage
+      - disk_usage
+      - memory_usage
+      - network_traffic
+      - system_load
+    RealTimeAnalytics:
+      type: object
+      description: Canonical payload returned by the real-time analytics endpoint
+      properties:
+        timestamp:
+          type: string
+          format: date-time
+          description: ISO timestamp of when the snapshot was generated
+        online_users:
+          type: integer
+          description: Users active in the last 30 minutes
+          minimum: 0
+        active_parties:
+          type: integer
+          description: Parties currently marked as live
+          minimum: 0
+        recent_activity:
+          type: array
+          description: Top events from the previous hour
+          items:
+            $ref: '#/components/schemas/RealTimeAnalyticsActivity'
+        engagement:
+          $ref: '#/components/schemas/RealTimeAnalyticsEngagement'
+        system_health:
+          $ref: '#/components/schemas/RealTimeAnalyticsSystemHealth'
+      required:
+      - active_parties
+      - engagement
+      - online_users
+      - recent_activity
+      - system_health
+      - timestamp
+    RealTimeAnalyticsResponse:
+      type: object
+      description: Standard success envelope for real-time analytics
+      properties:
+        success:
+          type: boolean
+          description: Indicates whether the request succeeded
+        message:
+          type: string
+          description: Human-friendly status message
+        data:
+          $ref: '#/components/schemas/RealTimeAnalytics'
+      required:
+      - data
+      - message
+      - success
           description: Additional data
       required:
       - message

--- a/frontend/components/dashboard/dashboard-layout.tsx
+++ b/frontend/components/dashboard/dashboard-layout.tsx
@@ -7,7 +7,7 @@ import type { ReactNode } from "react"
 import { cn } from "@/lib/utils"
 import { DashboardHeader } from "@/components/layout/dashboard-header"
 import MobileNavigation from "@/components/mobile/MobileNavigation"
-import { userApi, analyticsApi, User } from "@/lib/api-client"
+import { userApi, analyticsApi, User, NormalizedRealTimeAnalytics } from "@/lib/api-client"
 
 // Enhanced navigation with categories, icons, and metadata
 const navigationSections = [
@@ -56,8 +56,24 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
   const pathname = usePathname()
   const [isCollapsed, setIsCollapsed] = useState(false)
   const [user, setUser] = useState<User | null>(null)
-  const [onlineUsers, setOnlineUsers] = useState(0)
-  const [activeParties, setActiveParties] = useState(0)
+  const [liveStats, setLiveStats] = useState<NormalizedRealTimeAnalytics>({
+    timestamp: "",
+    onlineUsers: 0,
+    activeParties: 0,
+    recentActivity: [],
+    engagement: {
+      concurrentViewers: 0,
+      messagesPerMinute: 0,
+      reactionsPerMinute: 0
+    },
+    systemHealth: {
+      systemLoad: 0,
+      cpuUsage: 0,
+      memoryUsage: 0,
+      diskUsage: 0,
+      networkTraffic: 0
+    }
+  })
   const [loading, setLoading] = useState(true)
 
   // Load user data and real-time stats
@@ -87,10 +103,7 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
   const loadRealTimeStats = async () => {
     try {
       const realTimeData = await analyticsApi.getRealTime()
-      if (realTimeData) {
-        setOnlineUsers(realTimeData.online_users || 0)
-        setActiveParties(realTimeData.active_parties || 0)
-      }
+      setLiveStats(realTimeData)
     } catch (error) {
       console.error("Failed to load real-time stats:", error)
     }
@@ -208,12 +221,20 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
               {/* Quick Stats */}
               <div className="grid grid-cols-2 gap-3">
                 <div className="bg-white/5 rounded-lg p-3 text-center">
-                  <div className="text-lg font-bold text-white">{onlineUsers.toLocaleString()}</div>
+                  <div className="text-lg font-bold text-white">{liveStats.onlineUsers.toLocaleString()}</div>
                   <div className="text-xs text-white/60">Online Users</div>
                 </div>
                 <div className="bg-white/5 rounded-lg p-3 text-center">
-                  <div className="text-lg font-bold text-white">{activeParties}</div>
+                  <div className="text-lg font-bold text-white">{liveStats.activeParties}</div>
                   <div className="text-xs text-white/60">Live Parties</div>
+                </div>
+                <div className="bg-white/5 rounded-lg p-3 text-center">
+                  <div className="text-lg font-bold text-white">{liveStats.systemHealth.systemLoad.toFixed(1)}%</div>
+                  <div className="text-xs text-white/60">System Load</div>
+                </div>
+                <div className="bg-white/5 rounded-lg p-3 text-center">
+                  <div className="text-lg font-bold text-white">{liveStats.engagement.messagesPerMinute.toLocaleString()}</div>
+                  <div className="text-xs text-white/60">Messages / min</div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- normalize the backend real-time analytics payload to expose canonical metric names
- update the analytics API client to unwrap standard responses and deliver typed, normalized stats
- refresh dashboard and analytics UI to display live engagement and system health metrics while documenting the endpoint contract

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68de9510ba208328a062afb1954ee4ee