### PR TITLE
Add public party detail endpoint and surface guest playback info

### DIFF
--- a/backend/apps/parties/urls.py
+++ b/backend/apps/parties/urls.py
@@ -6,7 +6,8 @@ from django.urls import path, include
 from rest_framework.routers import DefaultRouter
 from .views import (
     WatchPartyViewSet, JoinByCodeView, PartySearchView,
-    PartyInvitationViewSet, PartyReportView, RecentPartiesView, PublicPartiesView
+    PartyInvitationViewSet, PartyReportView, RecentPartiesView, PublicPartiesView,
+    PublicPartyDetailView
 )
 from .views_enhanced import (
     generate_party_invite_code, join_by_invite_code, party_analytics,
@@ -23,6 +24,7 @@ router.register(r'invitations', PartyInvitationViewSet, basename='invitation')
 urlpatterns = [
     # Special endpoints first (before router includes)
     path('recent/', RecentPartiesView.as_view(), name='recent'),
+    path('public/<str:room_code>/', PublicPartyDetailView.as_view(), name='public-detail'),
     path('public/', PublicPartiesView.as_view(), name='public'),
     path('trending/', trending_parties, name='trending'),
     path('recommendations/', party_recommendations, name='recommendations'),

--- a/frontend/app/api/parties/public/[code]/route.ts
+++ b/frontend/app/api/parties/public/[code]/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from "next/server"
+
+const BACKEND_URL = process.env.BACKEND_URL || "http://localhost:8000"
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: { code: string } }
+) {
+  const roomCode = params.code
+
+  try {
+    const response = await fetch(
+      `${BACKEND_URL}/api/parties/public/${encodeURIComponent(roomCode)}/`,
+      {
+        method: "GET",
+        headers: {
+          "Accept": "application/json",
+        },
+        cache: "no-store",
+      }
+    )
+
+    let data: unknown = null
+
+    try {
+      data = await response.json()
+    } catch (error) {
+      if (response.status !== 204) {
+        console.warn("Failed to parse backend response as JSON", error)
+      }
+    }
+
+    if (data === null) {
+      return NextResponse.json({}, { status: response.status })
+    }
+
+    return NextResponse.json(data, { status: response.status })
+  } catch (error) {
+    console.error("Public party proxy error:", error)
+    return NextResponse.json(
+      { error: "Unable to load party details" },
+      { status: 500 }
+    )
+  }
+}

--- a/frontend/app/party/[code]/page.tsx
+++ b/frontend/app/party/[code]/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect, use } from "react"
-import { PublicPartyLayout } from "@/components/party/public-party-layout"
+import { PublicPartyLayout, type PublicPartyViewModel } from "@/components/party/public-party-layout"
 
 interface PublicPartyPageProps {
   params: Promise<{
@@ -9,72 +9,165 @@ interface PublicPartyPageProps {
   }>
 }
 
-interface PartyData {
+interface PublicPartyApiResponse {
   id: string
-  code: string
-  name: string
-  host: {
-    username: string
+  title: string
+  description?: string | null
+  room_code: string
+  visibility: string
+  host?: {
+    id: string
+    name: string
+    avatar?: string | null
+    is_premium?: boolean
   }
-  member_count: number
-  current_video?: {
+  video?: {
     id: string
     title: string
-    url: string
-    duration: number
-  }
-  settings: {
-    is_public: boolean
-    allow_guest_chat: boolean
+    duration?: string | number | null
+    duration_formatted?: string | null
+  } | null
+  participant_count?: number
+  allow_chat: boolean
+  allow_reactions: boolean
+  status: string
+  scheduled_start?: string | null
+  started_at?: string | null
+  ended_at?: string | null
+  current_timestamp?: string | number | null
+  current_timestamp_formatted?: string | null
+  is_playing: boolean
+  last_sync_at?: string | null
+}
+
+interface ApiErrorPayload {
+  detail?: string
+  error?: string
+  message?: string
+}
+
+const toStatusLabel = (status?: string) => {
+  if (!status) return "Unknown"
+  return status.charAt(0).toUpperCase() + status.slice(1)
+}
+
+const ensureString = (value: unknown) => {
+  if (typeof value === "string") return value
+  if (typeof value === "number") return value.toString()
+  return undefined
+}
+
+const mapPartyResponse = (data: PublicPartyApiResponse): PublicPartyViewModel => {
+  const host = data.host ?? { id: "", name: "Host" }
+  const statusLabel = toStatusLabel(data.status)
+  const playbackPosition = data.current_timestamp_formatted
+    ? data.current_timestamp_formatted
+    : ensureString(data.current_timestamp) ?? "00:00"
+
+  const videoDuration = data.video?.duration_formatted
+    ? data.video.duration_formatted
+    : ensureString(data.video?.duration)
+
+  return {
+    id: data.id,
+    title: data.title,
+    description: data.description ?? undefined,
+    roomCode: data.room_code,
+    host: {
+      id: host.id ?? "",
+      name: host.name ?? "Host",
+      avatar: host.avatar ?? undefined,
+      isPremium: host.is_premium ?? undefined,
+    },
+    participantCount: data.participant_count ?? 0,
+    allowChat: data.allow_chat,
+    allowReactions: data.allow_reactions,
+    status: data.status,
+    statusLabel,
+    isPlaying: data.is_playing,
+    playbackPosition,
+    lastSyncAt: data.last_sync_at ?? undefined,
+    video: data.video
+      ? {
+          id: data.video.id,
+          title: data.video.title,
+          durationLabel: videoDuration,
+        }
+      : undefined,
   }
 }
 
-/**
- * Public Party Page - Anonymous users can join with limited features
- * Features: Video sync + basic text chat only
- * No: Voice chat, emoji reactions, polls, games, etc.
- */
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === "object" && value !== null
+}
+
 export default function PublicPartyPage({ params }: PublicPartyPageProps) {
   const resolvedParams = use(params)
-  const [party, setParty] = useState<PartyData | null>(null)
+  const [party, setParty] = useState<PublicPartyViewModel | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [guestName, setGuestName] = useState("")
   const [hasJoined, setHasJoined] = useState(false)
+  const [joinError, setJoinError] = useState<string | null>(null)
 
   useEffect(() => {
-    loadPartyData()
-  }, [resolvedParams.code])
+    let isActive = true
 
-  const loadPartyData = async () => {
-    try {
-      // Fetch public party data (no auth required)
-      const response = await fetch(`/api/parties/public/${resolvedParams.code}/`)
-      
-      if (!response.ok) {
-        if (response.status === 404) {
-          throw new Error("Party not found")
+    const fetchParty = async () => {
+      setLoading(true)
+      setError(null)
+      setParty(null)
+      setHasJoined(false)
+      setGuestName("")
+      setJoinError(null)
+
+      try {
+        const response = await fetch(`/api/parties/public/${resolvedParams.code}/`, {
+          cache: "no-store",
+        })
+
+        let payload: unknown = null
+        try {
+          payload = await response.json()
+        } catch (parseError) {
+          payload = null
         }
-        throw new Error("Failed to load party")
-      }
-      
-      const data = await response.json()
-      
-      // Check if party allows guests
-      if (!data.settings?.is_public || !data.settings?.allow_guest_chat) {
-        throw new Error("This party is private")
-      }
-      
-      setParty(data)
-    } catch (err) {
-      console.error("Failed to load party:", err)
-      setError(err instanceof Error ? err.message : "Failed to load party")
-    } finally {
-      setLoading(false)
-    }
-  }
 
-  const [joinError, setJoinError] = useState<string | null>(null)
+        if (!response.ok || !isRecord(payload)) {
+          const errorPayload = (payload as ApiErrorPayload) ?? {}
+          const detail = errorPayload.detail || errorPayload.message || errorPayload.error
+
+          if (response.status === 404) {
+            throw new Error(detail || "Party not found")
+          }
+
+          if (response.status === 403) {
+            throw new Error(detail || "This party is private")
+          }
+
+          throw new Error(detail || "Failed to load party")
+        }
+
+        if (!isActive) return
+
+        setParty(mapPartyResponse(payload as PublicPartyApiResponse))
+      } catch (err) {
+        if (!isActive) return
+        console.error("Failed to load party:", err)
+        setError(err instanceof Error ? err.message : "Failed to load party")
+      } finally {
+        if (isActive) {
+          setLoading(false)
+        }
+      }
+    }
+
+    void fetchParty()
+
+    return () => {
+      isActive = false
+    }
+  }, [resolvedParams.code])
 
   const handleJoinParty = () => {
     setJoinError(null)
@@ -82,14 +175,13 @@ export default function PublicPartyPage({ params }: PublicPartyPageProps) {
       setJoinError("Please enter a name to join")
       return
     }
-    if (guestName.length < 2) {
+    if (guestName.trim().length < 2) {
       setJoinError("Name must be at least 2 characters")
       return
     }
     setHasJoined(true)
   }
 
-  // Loading state
   if (loading) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900">
@@ -101,8 +193,8 @@ export default function PublicPartyPage({ params }: PublicPartyPageProps) {
     )
   }
 
-  // Error state
   if (error || !party) {
+    const isPrivate = error === "This party is private"
     return (
       <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 px-4">
         <div className="w-full max-w-md rounded-2xl bg-white/5 p-8 text-center backdrop-blur-sm">
@@ -111,13 +203,13 @@ export default function PublicPartyPage({ params }: PublicPartyPageProps) {
             {error || "Party not found"}
           </h1>
           <p className="mb-6 text-white/70">
-            {error === "This party is private" 
+            {isPrivate
               ? "This party doesn't allow guest access. Please ask the host for an invite."
-              : "The party code might be incorrect or the party may have ended."}
+              : "The party code might be incorrect, private, or the party may have ended."}
           </p>
           <button
-            onClick={() => window.location.href = '/'}
-            className="inline-flex items-center justify-center rounded-lg bg-gradient-to-r from-purple-600 to-blue-600 px-6 py-3 font-semibold text-white hover:shadow-lg transition-all"
+            onClick={() => (window.location.href = "/")}
+            className="inline-flex items-center justify-center rounded-lg bg-gradient-to-r from-purple-600 to-blue-600 px-6 py-3 font-semibold text-white transition-all hover:shadow-lg"
           >
             Go to Homepage
           </button>
@@ -126,33 +218,40 @@ export default function PublicPartyPage({ params }: PublicPartyPageProps) {
     )
   }
 
-  // Join screen (before entering party)
   if (!hasJoined) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 px-4">
-        <div className="w-full max-w-md rounded-2xl bg-white/5 p-8 backdrop-blur-sm border border-white/10">
+        <div className="w-full max-w-md rounded-2xl border border-white/10 bg-white/5 p-8 backdrop-blur-sm">
           <div className="mb-6 text-center">
             <div className="mb-4 text-6xl">🎬</div>
-            <h1 className="mb-2 text-3xl font-bold text-white">{party.name}</h1>
+            <h1 className="mb-2 text-3xl font-bold text-white">{party.title}</h1>
             <p className="text-white/70">
-              Hosted by <span className="font-semibold text-purple-400">@{party.host.username}</span>
+              Hosted by <span className="font-semibold text-purple-400">{party.host.name}</span>
             </p>
             <p className="mt-2 text-sm text-white/50">
-              {party.member_count} {party.member_count === 1 ? 'person' : 'people'} watching
+              Room code: <span className="font-mono text-white/80">{party.roomCode}</span>
             </p>
+            <p className="mt-2 text-sm text-white/50">
+              {party.participantCount} {party.participantCount === 1 ? "person" : "people"} watching
+            </p>
+            <div className="mt-3 flex flex-col items-center gap-1 text-xs text-white/60">
+              <span>Status: {party.statusLabel}</span>
+              <span>Playback: {party.isPlaying ? "Playing" : "Paused"}</span>
+              <span>Position: {party.playbackPosition}</span>
+            </div>
           </div>
 
-          <div className="mb-6 rounded-lg bg-blue-500/10 border border-blue-500/30 p-4">
+          <div className="mb-6 rounded-lg border border-blue-500/30 bg-blue-500/10 p-4">
             <p className="text-sm text-blue-300">
-              <strong>👁️ Guest Mode:</strong> You can watch and chat in text only. 
+              <strong>👁️ Guest Mode:</strong> You can watch the synced stream and participate in text chat when enabled.
               Sign up for full features like voice chat and reactions!
             </p>
           </div>
 
           <div className="space-y-4">
             {joinError && (
-              <div className="rounded-lg bg-red-500/10 border border-red-500/30 p-3">
-                <p className="text-sm text-red-300 flex items-center gap-2">
+              <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-3">
+                <p className="flex items-center gap-2 text-sm text-red-300">
                   <span>❌</span>
                   {joinError}
                 </p>
@@ -169,7 +268,7 @@ export default function PublicPartyPage({ params }: PublicPartyPageProps) {
                 value={guestName}
                 onChange={(e) => {
                   setGuestName(e.target.value)
-                  setJoinError(null) // Clear error on input
+                  setJoinError(null)
                 }}
                 placeholder="Guest123"
                 maxLength={20}
@@ -179,14 +278,14 @@ export default function PublicPartyPage({ params }: PublicPartyPageProps) {
 
             <button
               onClick={handleJoinParty}
-              className="w-full rounded-lg bg-gradient-to-r from-purple-600 to-blue-600 py-3 font-semibold text-white hover:shadow-lg transition-all"
+              className="w-full rounded-lg bg-gradient-to-r from-purple-600 to-blue-600 py-3 font-semibold text-white transition-all hover:shadow-lg"
             >
               Join Party
             </button>
 
             <a
               href="/auth/register"
-              className="block text-center text-sm text-purple-400 hover:text-purple-300 transition-colors"
+              className="block text-center text-sm text-purple-400 transition-colors hover:text-purple-300"
             >
               Create an account for full features →
             </a>
@@ -196,10 +295,9 @@ export default function PublicPartyPage({ params }: PublicPartyPageProps) {
     )
   }
 
-  // Party room (after joining)
   return (
-    <PublicPartyLayout 
-      party={party} 
+    <PublicPartyLayout
+      party={party}
       guestName={guestName}
       onLeave={() => setHasJoined(false)}
     />

--- a/frontend/tests/public-party-layout.test.tsx
+++ b/frontend/tests/public-party-layout.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react"
+import { PublicPartyLayout, type PublicPartyViewModel } from "@/components/party/public-party-layout"
+
+describe("PublicPartyLayout", () => {
+  const baseParty: PublicPartyViewModel = {
+    id: "1",
+    title: "Demo Party",
+    roomCode: "DEMO123",
+    host: {
+      id: "host-1",
+      name: "Demo Host",
+    },
+    participantCount: 42,
+    allowChat: false,
+    allowReactions: true,
+    status: "live",
+    statusLabel: "Live",
+    isPlaying: true,
+    playbackPosition: "00:42",
+    lastSyncAt: "2024-05-01T12:00:00Z",
+    video: {
+      id: "video-1",
+      title: "Feature Film",
+      durationLabel: "01:45:00",
+    },
+  }
+
+  it("surfaces playback information and disables chat when chat is off", () => {
+    render(
+      <PublicPartyLayout
+        party={baseParty}
+        guestName="Sky"
+        onLeave={jest.fn()}
+      />
+    )
+
+    expect(screen.getByText(/Status: Live/i)).toBeInTheDocument()
+    expect(screen.getByTestId("playback-status")).toHaveTextContent("Playback: Playing")
+    expect(screen.getByTestId("playback-position")).toHaveTextContent("Position: 00:42")
+    expect(screen.getByTestId("playback-duration")).toHaveTextContent("Duration: 01:45:00")
+    expect(screen.getByText(/Chat is disabled by the host/i)).toBeInTheDocument()
+
+    const chatInput = screen.getByLabelText(/Chat message/i)
+    expect(chatInput).toBeDisabled()
+
+    const sendButton = screen.getByRole("button", { name: /send/i })
+    expect(sendButton).toBeDisabled()
+  })
+})

--- a/frontend/tests/setup.ts
+++ b/frontend/tests/setup.ts
@@ -1,1 +1,6 @@
 import "@testing-library/jest-dom"
+
+Object.defineProperty(window.HTMLElement.prototype, "scrollIntoView", {
+  value: jest.fn(),
+  writable: true,
+})


### PR DESCRIPTION
## Summary
- add an anonymous public party detail endpoint that filters by visibility and guest chat settings
- expose a Next.js proxy route and refresh the guest party page/layout to show playback state and chat availability
- cover the guest layout with a regression test for playback and chat restrictions

## Testing
- pnpm test -- public-party-layout.test.tsx

------
https://chatgpt.com/codex/tasks/task_b_68de950ce6948328939e45623c0a95f1