### PR TITLE
Add manual workflow to clear deployment caches

### DIFF
--- a/.github/workflows/clear-caches.yml
+++ b/.github/workflows/clear-caches.yml
@@ -1,0 +1,64 @@
+name: Clear Application Caches
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Which application caches should be cleared?"
+        required: true
+        default: all
+        type: choice
+        options:
+          - frontend
+          - backend
+          - all
+
+jobs:
+  clear-cache:
+    name: Clear caches on Lightsail instance
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      TARGET: ${{ github.event.inputs.target }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Remove caches over SSH
+        uses: appleboy/ssh-action@v1.0.3
+        env:
+          TARGET: ${{ env.TARGET }}
+        with:
+          host: ${{ secrets.LIGHTSAIL_HOST }}
+          username: deploy
+          key: ${{ secrets.LIGHTSAIL_SSH_KEY }}
+          envs: TARGET
+          script: |
+            set -e
+
+            APP_NAME=watch-party
+            APP_DIR=/srv/$APP_NAME
+
+            if [ ! -d "$APP_DIR" ]; then
+              git clone https://github.com/EL-HOUSS-BRAHIM/watch-party.git "$APP_DIR"
+            fi
+
+            cd "$APP_DIR"
+
+            if [ -f scripts/deployment/setup-repository.sh ]; then
+              bash scripts/deployment/setup-repository.sh
+              if [ -f /tmp/deployment-vars.sh ]; then
+                source /tmp/deployment-vars.sh
+                cd "$APP_DIR"
+              fi
+            else
+              git fetch origin
+              git checkout master 2>/dev/null || git checkout main
+              git reset --hard origin/$(git rev-parse --abbrev-ref HEAD)
+            fi
+
+            if [ ! -f scripts/deployment/clear-app-cache.sh ]; then
+              echo "Cache clearing script not found" >&2
+              exit 1
+            fi
+
+            bash scripts/deployment/clear-app-cache.sh "${TARGET:-all}"

--- a/scripts/deployment/clear-app-cache.sh
+++ b/scripts/deployment/clear-app-cache.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# =============================================================================
+# CLEAR APPLICATION CACHES
+# =============================================================================
+# Removes build and runtime cache directories for the frontend and backend
+# applications to ensure fresh assets are generated on the next deployment.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common-functions.sh"
+
+# Rehydrate APP_DIR/TARGET_BRANCH if setup script exported them previously
+if [ -f /tmp/deployment-vars.sh ]; then
+    source /tmp/deployment-vars.sh
+fi
+
+APP_NAME="${APP_NAME:-watch-party}"
+APP_DIR="${APP_DIR:-/srv/$APP_NAME}"
+TARGET="${1:-all}"
+
+case "$TARGET" in
+    frontend|backend|all)
+        ;;
+    *)
+        log_error "Invalid target '$TARGET'. Use frontend, backend, or all."
+        exit 1
+        ;;
+esac
+
+log_step "Clearing application caches (target: $TARGET)"
+
+clear_frontend_cache() {
+    if [ ! -d "$APP_DIR/frontend" ]; then
+        log_warning "Frontend directory not found at $APP_DIR/frontend"
+        return
+    fi
+
+    log_info "Removing Next.js build artifacts"
+    rm -rf "$APP_DIR/frontend/.next" \
+           "$APP_DIR/frontend/.turbo" \
+           "$APP_DIR/frontend/out"
+
+    log_info "Removing node_modules caches"
+    find "$APP_DIR/frontend" -type d -name ".cache" -prune -exec rm -rf {} + 2>/dev/null || true
+    rm -rf "$APP_DIR/frontend/node_modules/.cache" 2>/dev/null || true
+
+    log_success "Frontend caches cleared"
+}
+
+clear_backend_cache() {
+    if [ ! -d "$APP_DIR/backend" ]; then
+        log_warning "Backend directory not found at $APP_DIR/backend"
+        return
+    fi
+
+    log_info "Removing Python bytecode and cache directories"
+    find "$APP_DIR/backend" -type d \( -name "__pycache__" -o -name ".pytest_cache" -o -name ".mypy_cache" \) \
+        -prune -exec rm -rf {} + 2>/dev/null || true
+    find "$APP_DIR/backend" -type f -name "*.py[cod]" -delete 2>/dev/null || true
+
+    log_info "Removing collected static assets cache"
+    rm -rf "$APP_DIR/backend/staticfiles" 2>/dev/null || true
+
+    log_success "Backend caches cleared"
+}
+
+if [ "$TARGET" = "frontend" ] || [ "$TARGET" = "all" ]; then
+    clear_frontend_cache
+fi
+
+if [ "$TARGET" = "backend" ] || [ "$TARGET" = "all" ]; then
+    clear_backend_cache
+fi
+
+log_success "Cache cleanup complete"


### PR DESCRIPTION
## Summary
- add a manually-triggered GitHub Actions workflow that connects to the Lightsail host and clears selected caches
- introduce a reusable deployment script that deletes frontend and backend build/runtime cache directories on the server

## Testing
- bash -n scripts/deployment/clear-app-cache.sh

------
https://chatgpt.com/codex/tasks/task_b_68dfa35286e083289f5cd4e5f1c46b95