### PR TITLE
Refactor frontend auth to use cookie-based sessions

### DIFF
--- a/frontend/app/api/auth/login/route.ts
+++ b/frontend/app/api/auth/login/route.ts
@@ -86,12 +86,20 @@ export async function POST(request: NextRequest) {
 
       return nextResponse
     } else {
-      return NextResponse.json({ error: extractErrorMessage(data) }, { status: response.status })
+      const message = extractErrorMessage(data)
+      return NextResponse.json(
+        {
+          success: false,
+          error: message,
+          message,
+        },
+        { status: response.status }
+      )
     }
   } catch (error) {
     console.error("Login API error:", error)
     return NextResponse.json(
-      { error: "Internal server error" },
+      { success: false, error: "Internal server error", message: "Internal server error" },
       { status: 500 }
     )
   }

--- a/frontend/app/api/auth/logout/route.ts
+++ b/frontend/app/api/auth/logout/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server"
+
+const BACKEND_URL = process.env.BACKEND_URL || "https://be-watch-party.brahim-elhouss.me"
+
+const COOKIE_OPTIONS = {
+  httpOnly: true,
+  secure: process.env.NODE_ENV === "production",
+  sameSite: "lax" as const,
+  path: "/",
+}
+
+export async function POST(request: NextRequest) {
+  const refreshToken = request.cookies.get("refresh_token")?.value
+
+  if (refreshToken) {
+    try {
+      await fetch(`${BACKEND_URL}/api/auth/logout/`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ refresh: refreshToken }),
+      })
+    } catch (error) {
+      console.error("Failed to notify backend about logout", error)
+    }
+  }
+
+  const response = NextResponse.json({ success: true, message: "Logged out" })
+  response.cookies.set("access_token", "", { ...COOKIE_OPTIONS, maxAge: 0 })
+  response.cookies.set("refresh_token", "", { ...COOKIE_OPTIONS, maxAge: 0 })
+
+  return response
+}
+

--- a/frontend/app/api/auth/refresh/route.ts
+++ b/frontend/app/api/auth/refresh/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from "next/server"
+
+const BACKEND_URL = process.env.BACKEND_URL || "https://be-watch-party.brahim-elhouss.me"
+
+const COOKIE_OPTIONS = {
+  httpOnly: true,
+  secure: process.env.NODE_ENV === "production",
+  sameSite: "lax" as const,
+  path: "/",
+}
+
+export async function POST(request: NextRequest) {
+  const refreshToken = request.cookies.get("refresh_token")?.value
+
+  if (!refreshToken) {
+    const response = NextResponse.json({ error: "No refresh token" }, { status: 401 })
+    response.cookies.set("access_token", "", { ...COOKIE_OPTIONS, maxAge: 0 })
+    response.cookies.set("refresh_token", "", { ...COOKIE_OPTIONS, maxAge: 0 })
+    return response
+  }
+
+  try {
+    const backendResponse = await fetch(`${BACKEND_URL}/api/auth/refresh/`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ refresh: refreshToken }),
+    })
+
+    const data = await backendResponse.json().catch(() => ({}))
+
+    if (!backendResponse.ok) {
+      const response = NextResponse.json(
+        { error: data.detail || data.error || "Unable to refresh session" },
+        { status: backendResponse.status }
+      )
+
+      if (backendResponse.status === 401) {
+        response.cookies.set("access_token", "", { ...COOKIE_OPTIONS, maxAge: 0 })
+        response.cookies.set("refresh_token", "", { ...COOKIE_OPTIONS, maxAge: 0 })
+      }
+
+      return response
+    }
+
+    const newAccessToken = data.access_token ?? data.access
+    const newRefreshToken = data.refresh_token ?? data.refresh
+
+    const response = NextResponse.json({
+      success: true,
+      access_token: newAccessToken,
+      refresh_token: newRefreshToken,
+    })
+
+    if (newAccessToken) {
+      response.cookies.set("access_token", newAccessToken, {
+        ...COOKIE_OPTIONS,
+        maxAge: 60 * 60 * 24,
+      })
+    }
+
+    if (newRefreshToken) {
+      response.cookies.set("refresh_token", newRefreshToken, {
+        ...COOKIE_OPTIONS,
+        maxAge: 60 * 60 * 24 * 7,
+      })
+    }
+
+    return response
+  } catch (error) {
+    console.error("Refresh token error:", error)
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+  }
+}
+

--- a/frontend/app/api/auth/session/route.ts
+++ b/frontend/app/api/auth/session/route.ts
@@ -1,0 +1,117 @@
+import { NextRequest, NextResponse } from "next/server"
+
+const BACKEND_URL = process.env.BACKEND_URL || "https://be-watch-party.brahim-elhouss.me"
+
+const COOKIE_OPTIONS = {
+  httpOnly: true,
+  secure: process.env.NODE_ENV === "production",
+  sameSite: "lax" as const,
+  path: "/",
+}
+
+async function fetchProfile(accessToken: string) {
+  return fetch(`${BACKEND_URL}/api/auth/profile/`, {
+    method: "GET",
+    headers: {
+      "Authorization": `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+    },
+    cache: "no-store",
+  })
+}
+
+async function refreshAccessToken(refreshToken: string) {
+  return fetch(`${BACKEND_URL}/api/auth/refresh/`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ refresh: refreshToken }),
+  })
+}
+
+export async function GET(request: NextRequest) {
+  const accessTokenCookie = request.cookies.get("access_token")?.value
+  const refreshTokenCookie = request.cookies.get("refresh_token")?.value
+
+  if (!accessTokenCookie && !refreshTokenCookie) {
+    return NextResponse.json({ authenticated: false, user: null })
+  }
+
+  let accessToken = accessTokenCookie
+
+  try {
+    if (accessToken) {
+      const profileResponse = await fetchProfile(accessToken)
+
+      if (profileResponse.ok) {
+        const user = await profileResponse.json()
+        return NextResponse.json({ authenticated: true, user })
+      }
+
+      if (profileResponse.status !== 401 || !refreshTokenCookie) {
+        return NextResponse.json({ authenticated: false, user: null }, { status: profileResponse.status })
+      }
+    }
+
+    if (!refreshTokenCookie) {
+      const response = NextResponse.json({ authenticated: false, user: null }, { status: 401 })
+      response.cookies.set("access_token", "", { ...COOKIE_OPTIONS, maxAge: 0 })
+      return response
+    }
+
+    const refreshResponse = await refreshAccessToken(refreshTokenCookie)
+    const refreshData = await refreshResponse.json().catch(() => ({}))
+
+    if (!refreshResponse.ok) {
+      const response = NextResponse.json({ authenticated: false, user: null }, { status: refreshResponse.status })
+      response.cookies.set("access_token", "", { ...COOKIE_OPTIONS, maxAge: 0 })
+      if (refreshResponse.status === 401) {
+        response.cookies.set("refresh_token", "", { ...COOKIE_OPTIONS, maxAge: 0 })
+      }
+      return response
+    }
+
+    accessToken = refreshData.access_token ?? refreshData.access
+    const newRefreshToken = refreshData.refresh_token ?? refreshData.refresh
+
+    if (!accessToken) {
+      const response = NextResponse.json({ authenticated: false, user: null }, { status: 401 })
+      response.cookies.set("access_token", "", { ...COOKIE_OPTIONS, maxAge: 0 })
+      response.cookies.set("refresh_token", "", { ...COOKIE_OPTIONS, maxAge: 0 })
+      return response
+    }
+
+    const profileResponse = await fetchProfile(accessToken)
+
+    if (!profileResponse.ok) {
+      const response = NextResponse.json({ authenticated: false, user: null }, { status: profileResponse.status })
+      response.cookies.set("access_token", "", { ...COOKIE_OPTIONS, maxAge: 0 })
+      if (profileResponse.status === 401) {
+        response.cookies.set("refresh_token", "", { ...COOKIE_OPTIONS, maxAge: 0 })
+      }
+      return response
+    }
+
+    const user = await profileResponse.json()
+    const response = NextResponse.json({ authenticated: true, user })
+
+    response.cookies.set("access_token", accessToken, {
+      ...COOKIE_OPTIONS,
+      maxAge: 60 * 60 * 24,
+    })
+
+    if (newRefreshToken) {
+      response.cookies.set("refresh_token", newRefreshToken, {
+        ...COOKIE_OPTIONS,
+        maxAge: 60 * 60 * 24 * 7,
+      })
+    }
+
+    return response
+  } catch (error) {
+    console.error("Session check error:", error)
+    return NextResponse.json({ authenticated: false, user: null }, { status: 500 })
+  }
+}
+

--- a/frontend/app/api/proxy/[...path]/route.ts
+++ b/frontend/app/api/proxy/[...path]/route.ts
@@ -1,0 +1,146 @@
+import { NextRequest, NextResponse } from "next/server"
+
+const BACKEND_URL = process.env.BACKEND_URL || "https://be-watch-party.brahim-elhouss.me"
+
+const COOKIE_OPTIONS = {
+  httpOnly: true,
+  secure: process.env.NODE_ENV === "production",
+  sameSite: "lax" as const,
+  path: "/",
+}
+
+async function refreshAccessToken(refreshToken: string) {
+  const response = await fetch(`${BACKEND_URL}/api/auth/refresh/`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ refresh: refreshToken }),
+  })
+
+  const data = await response.json().catch(() => ({}))
+  return { response, data }
+}
+
+function copyHeaders(source: Headers, target: Headers) {
+  source.forEach((value, key) => {
+    const lowerKey = key.toLowerCase()
+    if (["set-cookie", "content-length", "transfer-encoding"].includes(lowerKey)) {
+      return
+    }
+    target.set(key, value)
+  })
+}
+
+export async function handler(
+  request: NextRequest,
+  context: { params: Promise<{ path: string[] }> }
+) {
+  const { path } = await context.params
+  const pathSegments = Array.isArray(path) ? path : []
+  const backendPath = pathSegments.join("/")
+  const url = new URL(request.url)
+  const targetUrl = `${BACKEND_URL}/${backendPath}${url.search}`
+
+  const requestBody =
+    request.method === "GET" || request.method === "HEAD" ? undefined : await request.text()
+
+  const accessToken = request.cookies.get("access_token")?.value
+  const refreshToken = request.cookies.get("refresh_token")?.value
+
+  const forwardRequest = async (token?: string) => {
+    const headers = new Headers()
+
+    request.headers.forEach((value, key) => {
+      const lowerKey = key.toLowerCase()
+      if (["host", "cookie", "content-length", "authorization"].includes(lowerKey)) {
+        return
+      }
+      headers.set(key, value)
+    })
+
+    if (token) {
+      headers.set("Authorization", `Bearer ${token}`)
+    }
+
+    return fetch(targetUrl, {
+      method: request.method,
+      headers,
+      body: requestBody,
+      cache: "no-store",
+    })
+  }
+
+  const initialResponse = await forwardRequest(accessToken)
+
+  if (initialResponse.status !== 401 || !refreshToken) {
+    const responseBody = await initialResponse.text()
+    const nextResponse = new NextResponse(responseBody, {
+      status: initialResponse.status,
+    })
+    copyHeaders(initialResponse.headers, nextResponse.headers)
+    return nextResponse
+  }
+
+  try {
+    const { response: refreshResponse, data: refreshData } = await refreshAccessToken(refreshToken)
+
+    if (!refreshResponse.ok) {
+      const responseBody = await initialResponse.text()
+      const nextResponse = new NextResponse(responseBody, {
+        status: initialResponse.status,
+      })
+      copyHeaders(initialResponse.headers, nextResponse.headers)
+      if (refreshResponse.status === 401) {
+        nextResponse.cookies.set("access_token", "", { ...COOKIE_OPTIONS, maxAge: 0 })
+        nextResponse.cookies.set("refresh_token", "", { ...COOKIE_OPTIONS, maxAge: 0 })
+      }
+      return nextResponse
+    }
+
+    const newAccessToken = refreshData.access_token ?? refreshData.access
+    const newRefreshToken = refreshData.refresh_token ?? refreshData.refresh
+
+    const retryResponse = await forwardRequest(newAccessToken)
+    const responseBody = await retryResponse.text()
+    const nextResponse = new NextResponse(responseBody, {
+      status: retryResponse.status,
+    })
+    copyHeaders(retryResponse.headers, nextResponse.headers)
+
+    if (newAccessToken) {
+      nextResponse.cookies.set("access_token", newAccessToken, {
+        ...COOKIE_OPTIONS,
+        maxAge: 60 * 60 * 24,
+      })
+    }
+
+    if (newRefreshToken) {
+      nextResponse.cookies.set("refresh_token", newRefreshToken, {
+        ...COOKIE_OPTIONS,
+        maxAge: 60 * 60 * 24 * 7,
+      })
+    }
+
+    return nextResponse
+  } catch (error) {
+    console.error("Proxy refresh error:", error)
+    const body = await initialResponse.text()
+    const nextResponse = new NextResponse(body, {
+      status: initialResponse.status,
+    })
+    copyHeaders(initialResponse.headers, nextResponse.headers)
+    return nextResponse
+  }
+}
+
+export {
+  handler as DELETE,
+  handler as GET,
+  handler as HEAD,
+  handler as OPTIONS,
+  handler as PATCH,
+  handler as POST,
+  handler as PUT,
+}
+

--- a/frontend/app/auth/login/page.tsx
+++ b/frontend/app/auth/login/page.tsx
@@ -22,19 +22,12 @@ export default function LoginPage() {
       const data = await authApi.login(formData)
 
       if (data.success) {
-        if (data.access_token) {
-          localStorage.setItem("access_token", data.access_token)
-        }
-        if (data.refresh_token) {
-          localStorage.setItem("refresh_token", data.refresh_token)
-        }
-
         const urlParams = new URLSearchParams(window.location.search)
         const redirect = urlParams.get("redirect") || "/dashboard"
 
         window.location.href = decodeURIComponent(redirect)
       } else {
-        setError("Login failed. Please check your credentials.")
+        setError(data.message || "Login failed. Please check your credentials.")
       }
     } catch (error) {
       console.error("Login error:", error)


### PR DESCRIPTION
## Summary
- update the login page and auth utilities to rely on the local `/api/auth/login` route and HTTP-only cookies instead of `localStorage`
- add cookie-aware auth/session API routes plus a backend proxy that forwards tokens and refreshes them automatically
- rework the shared API client to use the proxy, eliminate token reads from `localStorage`, and expose a session-aware `useAuth` hook

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68e14b9aa61c8328a02c13236bc3cdf0