### PR TITLE
Update Channels Redis backend path

### DIFF
--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -288,7 +288,7 @@ CELERY_TASK_ROUTES = {
 # Channels Configuration with support for AWS ElastiCache Valkey
 CHANNEL_LAYERS = {
     'default': {
-        'BACKEND': 'channels_redis.shared.RedisChannelLayer',
+        'BACKEND': 'channels_redis.core.RedisChannelLayer',
         'CONFIG': {
             "hosts": [config('CHANNEL_LAYERS_CONFIG_HOSTS', default=config('REDIS_URL', default='redis://127.0.0.1:6379/1'))],
             # SSL/TLS configuration for AWS ElastiCache


### PR DESCRIPTION
## Summary
- update the default Channels layer backend to use channels_redis.core.RedisChannelLayer
- verify the ASGI application loads successfully with production settings

## Testing
- ALLOWED_HOSTS=localhost DATABASE_URL=sqlite:///db.sqlite3 REDIS_URL=redis://127.0.0.1:6379/1 DJANGO_SETTINGS_MODULE=config.settings.production python -c "import config.asgi"

------
https://chatgpt.com/codex/tasks/task_b_68e14d63ca3c83289111c330bfe1cf0a