### PR TITLE
Fix default email backend configuration

### DIFF
--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -300,7 +300,7 @@ CHANNEL_LAYERS = {
 }
 
 # Email Configuration
-EMAIL_BACKEND = config('EMAIL_BACKEND', default='django.shared.mail.backends.console.EmailBackend')
+EMAIL_BACKEND = config('EMAIL_BACKEND', default='django.core.mail.backends.console.EmailBackend')
 EMAIL_HOST = config('EMAIL_HOST', default='')
 EMAIL_PORT = config('EMAIL_PORT', default=587, cast=int)
 EMAIL_HOST_USER = config('EMAIL_HOST_USER', default='')


### PR DESCRIPTION
## Summary
- update the base settings so the default email backend uses Django's console backend

## Testing
- DJANGO_SETTINGS_MODULE=config.settings.base python backend/manage.py sendtestemail user@example.com

------
https://chatgpt.com/codex/tasks/task_b_68e14d6ebb908328a932997dfa4d731a