### PR TITLE
Fix landing page layout width

### DIFF
--- a/frontend/components/layout/conditional-layout.tsx
+++ b/frontend/components/layout/conditional-layout.tsx
@@ -28,6 +28,8 @@ export function ConditionalLayout({ children }: ConditionalLayoutProps) {
   // Public party pages handle their own complete layout (no header/footer wrapper)
   const isPublicParty = pathname?.startsWith('/party/')
   
+  const isLanding = pathname === "/"
+
   if (isDashboard) {
     // Dashboard handles its own complete layout
     return <>{children}</>
@@ -54,9 +56,13 @@ export function ConditionalLayout({ children }: ConditionalLayoutProps) {
     <div className="flex min-h-screen flex-col">
       <MarketingHeader />
       <main className="flex-1">
-        <div className="mx-auto w-full max-w-6xl px-4 pb-16 pt-16 sm:px-8 mobile-content">
-          {children}
-        </div>
+        {isLanding ? (
+          <div className="mobile-content">{children}</div>
+        ) : (
+          <div className="mx-auto w-full max-w-6xl px-4 pb-16 pt-16 sm:px-8 mobile-content">
+            {children}
+          </div>
+        )}
       </main>
       <SiteFooter />
     </div>


### PR DESCRIPTION
## Summary
- detect when the marketing layout is rendering the homepage
- skip the constrained max-width wrapper so the landing sections can self-center

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e3714eebd08328b765f399c5d9e3dc